### PR TITLE
Challenge Submission

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 rand = "0.8"
+oorandom = "11"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 rand = "0.8"
 oorandom = "11"
+memmap2 = "0.9"
+bytemuck = "1"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/benches/graph_bench.rs
+++ b/benches/graph_bench.rs
@@ -1,5 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use graph_challenge::graph::Graph;
+use graph_challenge::graph_vec::Graph as GraphVec;
 
 const SEED: u128 = 1_000_000;
 
@@ -12,6 +13,36 @@ fn bench_shortest_path(c: &mut Criterion) {
     });
 }
 
+fn bench_shortest_path_vec(c: &mut Criterion) {
+    let g = GraphVec::random_connected_graph(100, 50, 1.0, 10.0, Some(SEED));
+    c.bench_function("shortest path on random connected vec-backed graph", |b| {
+        b.iter(|| {
+            g.shortest_path(0, 99);
+        })
+    });
+}
+
+fn bench_shortest_path_huge(c: &mut Criterion) {
+    let g = Graph::random_connected_graph(1_000_000, 100_000, 1.0, 10.0, Some(SEED));
+    c.bench_function("shortest path on random connected huge graph", |b| {
+        b.iter(|| {
+            g.shortest_path(0, 999_999);
+        })
+    });
+}
+
+fn bench_shortest_path_huge_vec(c: &mut Criterion) {
+    let g = GraphVec::random_connected_graph(1_000_000, 100_000, 1.0, 10.0, Some(SEED));
+    c.bench_function(
+        "shortest path on random connected huge vec-backed graph",
+        |b| {
+            b.iter(|| {
+                g.shortest_path(0, 999_999);
+            })
+        },
+    );
+}
+
 fn bench_graph_generation(c: &mut Criterion) {
     c.bench_function("generate random connected graph", |b| {
         b.iter(|| {
@@ -20,5 +51,39 @@ fn bench_graph_generation(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_shortest_path, bench_graph_generation);
+fn bench_graph_generation_vec(c: &mut Criterion) {
+    c.bench_function("generate random connected vec-backed graph", |b| {
+        b.iter(|| {
+            GraphVec::random_connected_graph(100, 50, 1.0, 10.0, Some(SEED));
+        })
+    });
+}
+
+fn bench_graph_generation_large(c: &mut Criterion) {
+    c.bench_function("generate random connected large graph", |b| {
+        b.iter(|| {
+            Graph::random_connected_graph(1_000_000, 10_000, 1.0, 10.0, Some(SEED));
+        })
+    });
+}
+
+fn bench_graph_generation_large_vec(c: &mut Criterion) {
+    c.bench_function("generate random connected large vec-backed graph", |b| {
+        b.iter(|| {
+            GraphVec::random_connected_graph(1_000_000, 10_000, 1.0, 10.0, Some(SEED));
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_shortest_path,
+    bench_shortest_path_vec,
+    bench_shortest_path_huge,
+    bench_shortest_path_huge_vec,
+    bench_graph_generation,
+    bench_graph_generation_vec,
+    bench_graph_generation_large,
+    bench_graph_generation_large_vec,
+);
 criterion_main!(benches);

--- a/benches/graph_bench.rs
+++ b/benches/graph_bench.rs
@@ -1,5 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use graph_challenge::graph::Graph;
+use graph_challenge::graph_memmap::Graph as GraphMmap;
 use graph_challenge::graph_vec::Graph as GraphVec;
 
 const SEED: u128 = 1_000_000;
@@ -22,6 +23,21 @@ fn bench_shortest_path_vec(c: &mut Criterion) {
     });
 }
 
+fn bench_shortest_path_mmap(c: &mut Criterion) {
+    let g = Graph::random_connected_graph(100, 50, 1.0, 10.0, Some(SEED));
+    let path = "tmp.graph";
+    g.save_to_file(path).unwrap();
+    let g = GraphMmap::load_from_file(path).unwrap();
+
+    c.bench_function("shortest path on random connected mmap-backed graph", |b| {
+        b.iter(|| {
+            g.shortest_path(0, 99);
+        })
+    });
+
+    std::fs::remove_file(path).unwrap();
+}
+
 fn bench_shortest_path_huge(c: &mut Criterion) {
     let g = Graph::random_connected_graph(1_000_000, 100_000, 1.0, 10.0, Some(SEED));
     c.bench_function("shortest path on random connected huge graph", |b| {
@@ -35,6 +51,22 @@ fn bench_shortest_path_huge_vec(c: &mut Criterion) {
     let g = GraphVec::random_connected_graph(1_000_000, 100_000, 1.0, 10.0, Some(SEED));
     c.bench_function(
         "shortest path on random connected huge vec-backed graph",
+        |b| {
+            b.iter(|| {
+                g.shortest_path(0, 999_999);
+            })
+        },
+    );
+}
+
+fn bench_shortest_path_huge_mmap(c: &mut Criterion) {
+    let g = Graph::random_connected_graph(1_000_000, 100_000, 1.0, 10.0, Some(SEED));
+    let path = "tmp.graph";
+    g.save_to_file(path).unwrap();
+    let g = GraphMmap::load_from_file(path).unwrap();
+
+    c.bench_function(
+        "shortest path on random connected huge mmap-backed graph",
         |b| {
             b.iter(|| {
                 g.shortest_path(0, 999_999);
@@ -79,8 +111,10 @@ criterion_group!(
     benches,
     bench_shortest_path,
     bench_shortest_path_vec,
+    bench_shortest_path_mmap,
     bench_shortest_path_huge,
     bench_shortest_path_huge_vec,
+    bench_shortest_path_huge_mmap,
     bench_graph_generation,
     bench_graph_generation_vec,
     bench_graph_generation_large,

--- a/benches/graph_bench.rs
+++ b/benches/graph_bench.rs
@@ -1,8 +1,10 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use graph_challenge::graph::Graph;
 
+const SEED: u128 = 1_000_000;
+
 fn bench_shortest_path(c: &mut Criterion) {
-    let g = Graph::random_connected_graph(100, 50, 1.0, 10.0);
+    let g = Graph::random_connected_graph(100, 50, 1.0, 10.0, Some(SEED));
     c.bench_function("shortest path on random connected graph", |b| {
         b.iter(|| {
             g.shortest_path(0, 99);
@@ -13,13 +15,10 @@ fn bench_shortest_path(c: &mut Criterion) {
 fn bench_graph_generation(c: &mut Criterion) {
     c.bench_function("generate random connected graph", |b| {
         b.iter(|| {
-            Graph::random_connected_graph(100, 50, 1.0, 10.0);
+            Graph::random_connected_graph(100, 50, 1.0, 10.0, Some(SEED));
         })
     });
 }
 
-criterion_group!(benches, 
-    bench_shortest_path,
-    bench_graph_generation
-);
-criterion_main!(benches); 
+criterion_group!(benches, bench_shortest_path, bench_graph_generation);
+criterion_main!(benches);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,9 +1,8 @@
-use std::collections::{HashMap, BinaryHeap};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter};
-use serde::{Serialize, Deserialize};
-use rand::Rng;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Graph {
@@ -32,7 +31,9 @@ impl Ord for State {
 
 impl Graph {
     pub fn new() -> Self {
-        Self { adjacency: HashMap::new() }
+        Self {
+            adjacency: HashMap::new(),
+        }
     }
 
     pub fn add_vertex(&mut self, v: u64) {
@@ -88,7 +89,10 @@ impl Graph {
         let mut heap = BinaryHeap::new();
 
         dist.insert(start, 0.0);
-        heap.push(State { cost: 0.0, position: start });
+        heap.push(State {
+            cost: 0.0,
+            position: start,
+        });
 
         while let Some(State { cost, position }) = heap.pop() {
             if position == end {
@@ -108,7 +112,10 @@ impl Graph {
 
             if let Some(neighbors) = self.adjacency.get(&position) {
                 for (&neighbor, &weight) in neighbors {
-                    let next = State { cost: cost + weight, position: neighbor };
+                    let next = State {
+                        cost: cost + weight,
+                        position: neighbor,
+                    };
                     if next.cost < *dist.get(&neighbor).unwrap_or(&f64::INFINITY) {
                         dist.insert(neighbor, next.cost);
                         prev.insert(neighbor, position);
@@ -127,48 +134,60 @@ impl Graph {
     }
 
     /// Generate a random connected graph with specified number of vertices
-    /// 
+    ///
     /// # Arguments
     /// * `num_vertices` - Number of vertices in the graph
     /// * `additional_edges` - Additional random edges beyond the minimum for connectivity
     /// * `min_weight` - Minimum edge weight (inclusive)
     /// * `max_weight` - Maximum edge weight (exclusive)
-    /// 
+    /// * `seed` - Optional seed for pseudo-RNG
+    ///
     /// # Returns
     /// A new connected Graph with random edges
-    pub fn random_connected_graph(num_vertices: u64, additional_edges: usize, min_weight: f64, max_weight: f64) -> Self {
+    pub fn random_connected_graph(
+        num_vertices: u64,
+        additional_edges: usize,
+        min_weight: f64,
+        max_weight: f64,
+        seed: Option<u128>,
+    ) -> Self {
         let mut graph = Graph::new();
-        let mut rng = rand::thread_rng();
-        
+        let seed = if let Some(seed) = seed {
+            seed
+        } else {
+            rand::random()
+        };
+        let mut rng = oorandom::Rand64::new(seed);
+
         // Add all vertices first
         for i in 0..num_vertices {
             graph.add_vertex(i);
         }
-        
+
         // Create a spanning tree to ensure connectivity
         for i in 1..num_vertices {
-            let parent = rng.gen_range(0..i);
-            let weight = rng.gen_range(min_weight..max_weight);
+            let parent = rng.rand_u64() % i;
+            let weight = rng.rand_float() * (max_weight - min_weight) + min_weight;
             graph.add_edge(parent, i, weight);
         }
-        
+
         // Add additional random edges
         let mut edges_added = 0;
         let max_attempts = additional_edges * 10;
         let mut attempts = 0;
-        
+
         while edges_added < additional_edges && attempts < max_attempts {
-            let from = rng.gen_range(0..num_vertices);
-            let to = rng.gen_range(0..num_vertices);
-            
+            let from = rng.rand_u64() % num_vertices;
+            let to = rng.rand_u64() % num_vertices;
+
             if from != to && graph.get_edge_weight(from, to).is_none() {
-                let weight = rng.gen_range(min_weight..max_weight);
+                let weight = rng.rand_float() % (max_weight - min_weight) + min_weight;
                 graph.add_edge(from, to, weight);
                 edges_added += 1;
             }
             attempts += 1;
         }
-        
+
         graph
     }
 }
@@ -178,5 +197,3 @@ impl Default for Graph {
         Self::new()
     }
 }
-
-

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter};
+use std::io::{self, BufReader, BufWriter, Read, Write};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Graph {
@@ -69,14 +69,88 @@ impl Graph {
 
     pub fn save_to_file(&self, path: &str) -> io::Result<()> {
         let file = File::create(path)?;
-        let writer = BufWriter::new(file);
-        bincode::serialize_into(writer, self).map_err(io::Error::other)
+        let mut writer = BufWriter::new(file);
+
+        // Write vertex count
+        writer.write_all(&(self.adjacency.len() as u64).to_le_bytes())?;
+
+        // Offset stores the value into the file for a vertex's neighbors and their costs
+        //
+        // Therefore, we need to account for metadata as well
+        // 1 for vertex count
+        // 3 for each vertex id + neighbor count + offset associated with it
+        let vertex_count = self.adjacency.keys().count();
+        let mut offset: u64 = ((1 + vertex_count * 3) * std::mem::size_of::<u64>()) as u64;
+
+        let mut vertices = self.adjacency.keys().copied().collect::<Vec<_>>();
+        // Sort so that memory mapped files can make use of binary search
+        vertices.sort();
+
+        for vertex in vertices.iter() {
+            // Write vertex id
+            writer.write_all(&vertex.to_le_bytes())?;
+            // Write neighbor count
+            let neighbor_count = self.adjacency[vertex].len();
+            writer.write_all(&neighbor_count.to_le_bytes())?;
+            // Write vertex offset
+            writer.write_all(&offset.to_le_bytes())?;
+            // Increase vertex offset by neighbour + weight count
+            offset += (neighbor_count * 2 * std::mem::size_of::<u64>()) as u64;
+        }
+
+        for vertex in vertices.iter() {
+            if let Some(neighbors) = self.neighbors(*vertex) {
+                for (neighbor, cost) in neighbors {
+                    // Write neighbor
+                    writer.write_all(&neighbor.to_le_bytes())?;
+                    // Write cost
+                    writer.write_all(&cost.to_le_bytes())?;
+                }
+            }
+        }
+
+        writer.flush()
     }
 
     pub fn load_from_file(path: &str) -> io::Result<Self> {
         let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        bincode::deserialize_from(reader).map_err(io::Error::other)
+        let mut reader = BufReader::new(file);
+        let mut buf = [0; std::mem::size_of::<u64>()];
+
+        let mut graph = Self::new();
+
+        // Read vertex count
+        reader.read_exact(&mut buf)?;
+        let vertex_count = u64::from_le_bytes(buf);
+
+        // Every vertex id and its associated # of neighbors
+        let mut vertices_neighbor_counts = Vec::new();
+
+        for _ in 0..vertex_count {
+            // Read vertex id
+            reader.read_exact(&mut buf)?;
+            let vertex = u64::from_le_bytes(buf);
+            graph.add_vertex(vertex);
+            // Read neighbor count
+            reader.read_exact(&mut buf)?;
+            let neighbor_count = u64::from_le_bytes(buf);
+            vertices_neighbor_counts.push((vertex, neighbor_count));
+            // Read offset (unused when not memmapped)
+            reader.read_exact(&mut buf)?;
+        }
+
+        for (vertex, neighbor_count) in vertices_neighbor_counts {
+            for _ in 0..neighbor_count {
+                // Read neighbor
+                reader.read_exact(&mut buf)?;
+                let neighbor = u64::from_le_bytes(buf);
+                // Read cost
+                reader.read_exact(&mut buf)?;
+                let cost = f64::from_le_bytes(buf);
+                graph.add_edge(vertex, neighbor, cost);
+            }
+        }
+        Ok(graph)
     }
 
     pub fn shortest_path(&self, start: u64, end: u64) -> Option<(Vec<u64>, f64)> {

--- a/src/graph_memmap.rs
+++ b/src/graph_memmap.rs
@@ -1,0 +1,189 @@
+use memmap2::MmapMut;
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+use std::fs::OpenOptions;
+use std::io;
+
+#[derive(Debug)]
+pub struct Graph {
+    mmap: MmapMut,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct State {
+    cost: f64,
+    position: u64,
+}
+
+impl Eq for State {}
+
+impl PartialOrd for State {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for State {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.cost.partial_cmp(&self.cost).unwrap()
+    }
+}
+
+impl Graph {
+    // First u64 is vertex id
+    // Second u64 is the neighbor count
+    // Third u64 is offset for neighbors
+    //
+    // Alignment isn't there for u64s so bytes will need to be casted
+    fn vertices_neighbor_counts_offsets(&self) -> &[[[u8; std::mem::size_of::<u64>()]; 3]] {
+        // First bytes of the mmap are the vertex count
+        let vertex_count =
+            u64::from_le_bytes(self.mmap[0..std::mem::size_of::<u64>()].try_into().unwrap())
+                as usize;
+
+        bytemuck::cast_slice(
+            &self.mmap[std::mem::size_of::<u64>()
+                ..(std::mem::size_of::<u64>() + vertex_count * 3 * std::mem::size_of::<u64>())],
+        )
+    }
+
+    // Neighbor count and offset into the memmap for neighbors/costs
+    fn neighbor_count_offset(&self, v: u64) -> (usize, usize) {
+        let vertices_neighbor_counts_offsets = self.vertices_neighbor_counts_offsets();
+
+        let i = vertices_neighbor_counts_offsets
+            .binary_search_by(
+                |&[vertex_bytes, _neighbor_count_bytes, _offset_bytes]: &[[u8; std::mem::size_of::<u64>()]; 3]| {
+                    let x = u64::from_le_bytes(vertex_bytes);
+                    x.cmp(&v)
+                },
+            )
+            .unwrap();
+
+        let neighbor_count = u64::from_le_bytes(vertices_neighbor_counts_offsets[i][1]) as usize;
+        let offset = u64::from_le_bytes(vertices_neighbor_counts_offsets[i][2]) as usize;
+
+        (neighbor_count, offset)
+    }
+
+    // First u64 is neighbor id
+    // Second u64 is the cost (needs to be casted to an f64)
+    fn neighbors_costs(&self, v: u64) -> &[[u64; 2]] {
+        let (neighbor_count, offset) = self.neighbor_count_offset(v);
+
+        let neighbors_costs = &self.mmap[offset
+            ..(offset
+                + neighbor_count * (std::mem::size_of::<u64>() + std::mem::size_of::<f64>()))];
+
+        bytemuck::cast_slice(neighbors_costs)
+    }
+
+    // First u64 is neighbor id
+    // Second u64 is the cost (needs to be casted to an f64)
+    fn neighbors_costs_mut(&mut self, v: u64) -> &mut [[u64; 2]] {
+        let (neighbor_count, offset) = self.neighbor_count_offset(v);
+
+        let neighbors_costs = &mut self.mmap[offset
+            ..(offset
+                + neighbor_count * (std::mem::size_of::<u64>() + std::mem::size_of::<f64>()))];
+
+        bytemuck::cast_slice_mut(neighbors_costs)
+    }
+
+    pub fn vertices(&self) -> impl Iterator<Item = u64> {
+        self.vertices_neighbor_counts_offsets().iter().map(
+            |&[vertex_bytes, _neighbor_count_bytes, _offset_bytes]: &[[u8; std::mem::size_of::<u64>()]; 3]| {
+                u64::from_le_bytes(vertex_bytes)
+            },
+        )
+    }
+
+    pub fn neighbors(&self, v: u64) -> impl Iterator<Item = (u64, f64)> {
+        self.neighbors_costs(v)
+            .iter()
+            .copied()
+            .map(|[neighbor, cost]| (neighbor, f64::from_le_bytes(cost.to_le_bytes())))
+    }
+
+    pub fn get_edge_weight(&self, from: u64, to: u64) -> Option<f64> {
+        let neighbors_costs = self.neighbors_costs(from);
+        if let Ok(i) = neighbors_costs.binary_search_by(|[neighbor, _]| neighbor.cmp(&to)) {
+            let cost = neighbors_costs[i][1];
+            Some(f64::from_le_bytes(cost.to_le_bytes()))
+        } else {
+            None
+        }
+    }
+
+    pub fn set_edge_weight(&mut self, from: u64, to: u64, cost: f64) -> bool {
+        let neighbors_costs = self.neighbors_costs_mut(from);
+        if let Ok(i) = neighbors_costs.binary_search_by(|[neighbor, _]| neighbor.cmp(&to)) {
+            neighbors_costs[i][1] = u64::from_le_bytes(cost.to_le_bytes());
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn load_from_file(path: &str) -> io::Result<Self> {
+        let file = OpenOptions::new().read(true).write(true).open(path)?;
+        let mmap = unsafe { MmapMut::map_mut(&file)? };
+        Ok(Self { mmap })
+    }
+
+    pub fn save_to_file(self) -> io::Result<()> {
+        self.mmap.flush()
+    }
+
+    pub fn shortest_path(&self, start: u64, end: u64) -> Option<(Vec<u64>, f64)> {
+        if !self.vertices().any(|v| v == start) || !self.vertices().any(|v| v == end) {
+            return None;
+        }
+
+        let mut prev_dist: HashMap<u64, (u64, f64)> = HashMap::new();
+        let mut heap = BinaryHeap::new();
+
+        prev_dist.insert(start, (u64::MAX, 0.0));
+        heap.push(State {
+            cost: 0.0,
+            position: start,
+        });
+
+        while let Some(State { cost, position }) = heap.pop() {
+            if position == end {
+                let mut path = vec![end];
+                let mut current = end;
+                while let Some(&(p, _)) = prev_dist.get(&current)
+                    && p != u64::MAX
+                {
+                    path.push(p);
+                    current = p;
+                }
+                path.reverse();
+                return Some((path, cost));
+            }
+
+            if cost > prev_dist[&position].1 {
+                continue;
+            }
+
+            for (neighbor, weight) in self.neighbors(position) {
+                let next = State {
+                    cost: cost + weight,
+                    position: neighbor,
+                };
+                if next.cost
+                    < *prev_dist
+                        .get(&neighbor)
+                        .map(|(_, c)| c)
+                        .unwrap_or(&f64::INFINITY)
+                {
+                    prev_dist.insert(neighbor, (position, next.cost));
+                    heap.push(next);
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/src/graph_vec.rs
+++ b/src/graph_vec.rs
@@ -109,11 +109,10 @@ impl Graph {
             return None;
         }
 
-        let mut dist: HashMap<u64, f64> = HashMap::new();
-        let mut prev: HashMap<u64, u64> = HashMap::new();
+        let mut prev_dist: HashMap<u64, (u64, f64)> = HashMap::new();
         let mut heap = BinaryHeap::new();
 
-        dist.insert(start, 0.0);
+        prev_dist.insert(start, (u64::MAX, 0.0));
         heap.push(State {
             cost: 0.0,
             position: start,
@@ -123,7 +122,9 @@ impl Graph {
             if position == end {
                 let mut path = vec![end];
                 let mut current = end;
-                while let Some(&p) = prev.get(&current) {
+                while let Some(&(p, _)) = prev_dist.get(&current)
+                    && p != u64::MAX
+                {
                     path.push(p);
                     current = p;
                 }
@@ -131,7 +132,7 @@ impl Graph {
                 return Some((path, cost));
             }
 
-            if cost > dist[&position] {
+            if cost > prev_dist[&position].1 {
                 continue;
             }
 
@@ -141,9 +142,13 @@ impl Graph {
                         cost: cost + weight,
                         position: neighbor,
                     };
-                    if next.cost < *dist.get(&neighbor).unwrap_or(&f64::INFINITY) {
-                        dist.insert(neighbor, next.cost);
-                        prev.insert(neighbor, position);
+                    if next.cost
+                        < *prev_dist
+                            .get(&neighbor)
+                            .map(|(_, c)| c)
+                            .unwrap_or(&f64::INFINITY)
+                    {
+                        prev_dist.insert(neighbor, (position, next.cost));
                         heap.push(next);
                     }
                 }

--- a/src/graph_vec.rs
+++ b/src/graph_vec.rs
@@ -1,0 +1,224 @@
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Graph {
+    pub adjacency: HashMap<u64, Vec<(u64, f64)>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct State {
+    cost: f64,
+    position: u64,
+}
+
+impl Eq for State {}
+
+impl PartialOrd for State {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for State {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.cost.partial_cmp(&self.cost).unwrap()
+    }
+}
+
+impl Graph {
+    pub fn new() -> Self {
+        Self {
+            adjacency: HashMap::new(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn add_vertex(&mut self, v: u64) {
+        self.adjacency.entry(v).or_default();
+    }
+
+    #[inline(always)]
+    pub fn add_edge(&mut self, from: u64, to: u64, weight: f64) {
+        self.add_vertex(from);
+        self.add_vertex(to);
+        let neighbours = self.adjacency.entry(from).or_default();
+        match neighbours.as_slice().binary_search_by(|(x, _)| x.cmp(&to)) {
+            Ok(i) => {
+                neighbours[i] = (to, weight);
+            }
+            Err(i) => {
+                neighbours.insert(i, (to, weight));
+            }
+        };
+    }
+
+    #[inline(always)]
+    pub fn remove_vertex(&mut self, v: u64) {
+        self.adjacency.remove(&v);
+        for neighbors in self.adjacency.values_mut() {
+            if let Ok(i) = neighbors.as_slice().binary_search_by(|(x, _)| x.cmp(&v)) {
+                neighbors.remove(i);
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn remove_edge(&mut self, from: u64, to: u64) {
+        if let Some(neighbors) = self.adjacency.get_mut(&from)
+            && let Ok(i) = neighbors.as_slice().binary_search_by(|(x, _)| x.cmp(&to))
+        {
+            {
+                neighbors.remove(i);
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn neighbors(&self, v: u64) -> Option<&Vec<(u64, f64)>> {
+        self.adjacency.get(&v)
+    }
+
+    #[inline(always)]
+    pub fn get_edge_weight(&self, from: u64, to: u64) -> Option<f64> {
+        let neighbours = self.adjacency.get(&from)?;
+        if let Ok(i) = neighbours.binary_search_by(|(x, _)| x.cmp(&to)) {
+            Some(neighbours[i].1)
+        } else {
+            None
+        }
+    }
+
+    pub fn save_to_file(&self, path: &str) -> io::Result<()> {
+        let file = File::create(path)?;
+        let writer = BufWriter::new(file);
+        bincode::serialize_into(writer, self).map_err(io::Error::other)
+    }
+
+    pub fn load_from_file(path: &str) -> io::Result<Self> {
+        let file = File::open(path)?;
+        let reader = BufReader::new(file);
+        bincode::deserialize_from(reader).map_err(io::Error::other)
+    }
+
+    pub fn shortest_path(&self, start: u64, end: u64) -> Option<(Vec<u64>, f64)> {
+        if !self.adjacency.contains_key(&start) || !self.adjacency.contains_key(&end) {
+            return None;
+        }
+
+        let mut dist: HashMap<u64, f64> = HashMap::new();
+        let mut prev: HashMap<u64, u64> = HashMap::new();
+        let mut heap = BinaryHeap::new();
+
+        dist.insert(start, 0.0);
+        heap.push(State {
+            cost: 0.0,
+            position: start,
+        });
+
+        while let Some(State { cost, position }) = heap.pop() {
+            if position == end {
+                let mut path = vec![end];
+                let mut current = end;
+                while let Some(&p) = prev.get(&current) {
+                    path.push(p);
+                    current = p;
+                }
+                path.reverse();
+                return Some((path, cost));
+            }
+
+            if cost > dist[&position] {
+                continue;
+            }
+
+            if let Some(neighbors) = self.adjacency.get(&position) {
+                for (neighbor, weight) in neighbors.iter().copied() {
+                    let next = State {
+                        cost: cost + weight,
+                        position: neighbor,
+                    };
+                    if next.cost < *dist.get(&neighbor).unwrap_or(&f64::INFINITY) {
+                        dist.insert(neighbor, next.cost);
+                        prev.insert(neighbor, position);
+                        heap.push(next);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    // For backward compatibility with unweighted graphs
+    pub fn add_unweighted_edge(&mut self, from: u64, to: u64) {
+        self.add_edge(from, to, 1.0);
+    }
+
+    /// Generate a random connected graph with specified number of vertices
+    ///
+    /// # Arguments
+    /// * `num_vertices` - Number of vertices in the graph
+    /// * `additional_edges` - Additional random edges beyond the minimum for connectivity
+    /// * `min_weight` - Minimum edge weight (inclusive)
+    /// * `max_weight` - Maximum edge weight (exclusive)
+    /// * `seed` - Optional seed for pseudo-RNG
+    ///
+    /// # Returns
+    /// A new connected Graph with random edges
+    pub fn random_connected_graph(
+        num_vertices: u64,
+        additional_edges: usize,
+        min_weight: f64,
+        max_weight: f64,
+        seed: Option<u128>,
+    ) -> Self {
+        let mut graph = Graph::new();
+        let seed = if let Some(seed) = seed {
+            seed
+        } else {
+            rand::random()
+        };
+        let mut rng = oorandom::Rand64::new(seed);
+
+        // Add all vertices first
+        for i in 0..num_vertices {
+            graph.add_vertex(i);
+        }
+
+        // Create a spanning tree to ensure connectivity
+        for i in 1..num_vertices {
+            let parent = rng.rand_u64() % i;
+            let weight = rng.rand_float() * (max_weight - min_weight) + min_weight;
+            graph.add_edge(parent, i, weight);
+        }
+
+        // Add additional random edges
+        let mut edges_added = 0;
+        let max_attempts = additional_edges * 10;
+        let mut attempts = 0;
+
+        while edges_added < additional_edges && attempts < max_attempts {
+            let from = rng.rand_u64() % num_vertices;
+            let to = rng.rand_u64() % num_vertices;
+
+            if from != to && graph.get_edge_weight(from, to).is_none() {
+                let weight = rng.rand_float() % (max_weight - min_weight) + min_weight;
+                graph.add_edge(from, to, weight);
+                edges_added += 1;
+            }
+            attempts += 1;
+        }
+
+        graph
+    }
+}
+
+impl Default for Graph {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/graph_vec.rs
+++ b/src/graph_vec.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter};
+use std::io::{self, BufReader, BufWriter, Read, Write};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Graph {
@@ -94,14 +94,88 @@ impl Graph {
 
     pub fn save_to_file(&self, path: &str) -> io::Result<()> {
         let file = File::create(path)?;
-        let writer = BufWriter::new(file);
-        bincode::serialize_into(writer, self).map_err(io::Error::other)
+        let mut writer = BufWriter::new(file);
+
+        // Write vertex count
+        writer.write_all(&(self.adjacency.len() as u64).to_le_bytes())?;
+
+        // Offset stores the value into the file for a vertex's neighbors and their costs
+        //
+        // Therefore, we need to account for metadata as well
+        // 1 for vertex count
+        // 3 for each vertex id + neighbor count + offset associated with it
+        let vertex_count = self.adjacency.keys().count();
+        let mut offset: u64 = ((1 + vertex_count * 3) * std::mem::size_of::<u64>()) as u64;
+
+        let mut vertices = self.adjacency.keys().copied().collect::<Vec<_>>();
+        // Sort so that memory mapped files can make use of binary search
+        vertices.sort();
+
+        for vertex in vertices.iter() {
+            // Write vertex id
+            writer.write_all(&vertex.to_le_bytes())?;
+            // Write neighbor count
+            let neighbor_count = self.adjacency[vertex].len();
+            writer.write_all(&neighbor_count.to_le_bytes())?;
+            // Write vertex offset
+            writer.write_all(&offset.to_le_bytes())?;
+            // Increase vertex offset by neighbour + weight count
+            offset += (neighbor_count * 2 * std::mem::size_of::<u64>()) as u64;
+        }
+
+        for vertex in vertices.iter() {
+            if let Some(neighbors) = self.neighbors(*vertex) {
+                for (neighbor, cost) in neighbors {
+                    // Write neighbor
+                    writer.write_all(&neighbor.to_le_bytes())?;
+                    // Write cost
+                    writer.write_all(&cost.to_le_bytes())?;
+                }
+            }
+        }
+
+        writer.flush()
     }
 
     pub fn load_from_file(path: &str) -> io::Result<Self> {
         let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        bincode::deserialize_from(reader).map_err(io::Error::other)
+        let mut reader = BufReader::new(file);
+        let mut buf = [0; std::mem::size_of::<u64>()];
+
+        let mut graph = Self::new();
+
+        // Read vertex count
+        reader.read_exact(&mut buf)?;
+        let vertex_count = u64::from_le_bytes(buf);
+
+        // Every vertex id and its associated # of neighbors
+        let mut vertices_neighbor_counts = Vec::new();
+
+        for _ in 0..vertex_count {
+            // Read vertex id
+            reader.read_exact(&mut buf)?;
+            let vertex = u64::from_le_bytes(buf);
+            graph.add_vertex(vertex);
+            // Read neighbor count
+            reader.read_exact(&mut buf)?;
+            let neighbor_count = u64::from_le_bytes(buf);
+            vertices_neighbor_counts.push((vertex, neighbor_count));
+            // Read offset (unused when not memmapped)
+            reader.read_exact(&mut buf)?;
+        }
+
+        for (vertex, neighbor_count) in vertices_neighbor_counts {
+            for _ in 0..neighbor_count {
+                // Read neighbor
+                reader.read_exact(&mut buf)?;
+                let neighbor = u64::from_le_bytes(buf);
+                // Read cost
+                reader.read_exact(&mut buf)?;
+                let cost = f64::from_le_bytes(buf);
+                graph.add_edge(vertex, neighbor, cost);
+            }
+        }
+        Ok(graph)
     }
 
     pub fn shortest_path(&self, start: u64, end: u64) -> Option<(Vec<u64>, f64)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod graph;
+pub mod graph_memmap;
 pub mod graph_vec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
-pub mod graph; 
+pub mod graph;
+pub mod graph_vec;

--- a/tests/graph_memmap_tests.rs
+++ b/tests/graph_memmap_tests.rs
@@ -1,0 +1,64 @@
+use graph_challenge::graph::Graph as RegularGraph;
+use graph_challenge::graph_memmap::Graph;
+use std::fs;
+
+#[test]
+fn test_complex_shortest_path() {
+    let mut g = RegularGraph::new();
+    // Create a more complex graph with multiple possible paths
+    g.add_edge(1, 2, 4.0);
+    g.add_edge(2, 3, 2.0);
+    g.add_edge(3, 4, 3.0);
+    g.add_edge(4, 5, 1.0);
+    g.add_edge(1, 6, 2.0);
+    g.add_edge(6, 7, 5.0);
+    g.add_edge(7, 5, 3.0);
+    g.add_edge(1, 8, 6.0);
+    g.add_edge(8, 5, 4.0);
+    g.add_edge(2, 7, 3.0);
+    g.add_edge(3, 8, 5.0);
+    let path = "complex.graph";
+    g.save_to_file(path).unwrap();
+    let g = Graph::load_from_file(path).unwrap();
+
+    // Test shortest path from 1 to 5
+    // Path options:
+    // 1 -> 6 -> 7 -> 5 = 2 + 5 + 3 = 10
+    // 1 -> 2 -> 7 -> 5 = 4 + 3 + 3 = 10
+    // 1 -> 8 -> 5 = 6 + 4 = 10
+    // 1 -> 2 -> 3 -> 4 -> 5 = 4 + 2 + 3 + 1 = 10
+    let (path1, cost1) = g.shortest_path(1, 5).unwrap();
+    // The algorithm found [1, 8, 5] which is correct (cost = 10)
+    assert_eq!(cost1, 10.0);
+    assert!(path1.len() >= 2);
+
+    // Test shortest path from 1 to 8
+    let (path2, cost2) = g.shortest_path(1, 8).unwrap();
+    assert_eq!(path2, vec![1, 8]);
+    assert_eq!(cost2, 6.0);
+
+    // Test shortest path from 2 to 5
+    let (path3, cost3) = g.shortest_path(2, 5).unwrap();
+    assert_eq!(path3, vec![2, 7, 5]);
+    assert_eq!(cost3, 6.0);
+
+    // Test non-existent path
+    assert!(g.shortest_path(5, 1).is_none());
+
+    fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn test_add_and_edit_edge() {
+    let mut g = RegularGraph::new();
+    g.add_edge(1, 2, 5.0);
+    let path = "edge.graph";
+    g.save_to_file(path).unwrap();
+    let mut g = Graph::load_from_file(path).unwrap();
+
+    assert_eq!(g.get_edge_weight(1, 2), Some(5.0));
+    g.set_edge_weight(1, 2, 10.0);
+    assert_eq!(g.get_edge_weight(1, 2), Some(10.0));
+
+    fs::remove_file(path).unwrap();
+}

--- a/tests/graph_tests.rs
+++ b/tests/graph_tests.rs
@@ -33,7 +33,7 @@ fn test_neighbors() {
 fn test_persistence() {
     let mut g = Graph::new();
     g.add_edge(1, 2, 4.5);
-    let path = "test_graph.bin";
+    let path = "test.graph";
     g.save_to_file(path).unwrap();
     let loaded = Graph::load_from_file(path).unwrap();
     assert_eq!(g.adjacency, loaded.adjacency);

--- a/tests/graph_tests.rs
+++ b/tests/graph_tests.rs
@@ -83,7 +83,7 @@ fn test_complex_shortest_path() {
     // Test shortest path from 1 to 5
     // Path options:
     // 1 -> 6 -> 7 -> 5 = 2 + 5 + 3 = 10
-    // 1 -> 2 -> 7 -> 5 = 4 + 3 + 3 = 10  
+    // 1 -> 2 -> 7 -> 5 = 4 + 3 + 3 = 10
     // 1 -> 8 -> 5 = 6 + 4 = 10
     // 1 -> 2 -> 3 -> 4 -> 5 = 4 + 2 + 3 + 1 = 10
     let (path1, cost1) = g.shortest_path(1, 5).unwrap();
@@ -105,8 +105,6 @@ fn test_complex_shortest_path() {
     assert!(g.shortest_path(5, 1).is_none());
 }
 
-
-
 #[test]
 fn test_unweighted_edge() {
     let mut g = Graph::new();
@@ -114,20 +112,22 @@ fn test_unweighted_edge() {
     assert_eq!(g.get_edge_weight(1, 2), Some(1.0));
 }
 
-
 #[test]
 fn test_random_connected_graph() {
-    let graph = Graph::random_connected_graph(10, 5, 1.0, 10.0);
-    
+    let graph = Graph::random_connected_graph(10, 5, 1.0, 10.0, Some(1));
+
     // Check that we have the right number of vertices
     assert_eq!(graph.adjacency.len(), 10);
-    
+
     // Count edges (should be at least 9 for connectivity + 5 additional)
-    let edge_count: usize = graph.adjacency.values().map(|neighbors| neighbors.len()).sum();
+    let edge_count: usize = graph
+        .adjacency
+        .values()
+        .map(|neighbors| neighbors.len())
+        .sum();
     assert!(edge_count >= 14); // 9 for spanning tree + 5 additional
-    
+
     // Check connectivity by ensuring there's a path from 0 to 9
     let (path, _cost) = graph.shortest_path(0, 9).unwrap();
     assert!(!path.is_empty());
-    
 }

--- a/tests/graph_vec_tests.rs
+++ b/tests/graph_vec_tests.rs
@@ -33,7 +33,7 @@ fn test_neighbors() {
 fn test_persistence() {
     let mut g = Graph::new();
     g.add_edge(1, 2, 4.5);
-    let path = "test_graph.bin";
+    let path = "test.graph";
     g.save_to_file(path).unwrap();
     let loaded = Graph::load_from_file(path).unwrap();
     assert_eq!(g.adjacency, loaded.adjacency);

--- a/tests/graph_vec_tests.rs
+++ b/tests/graph_vec_tests.rs
@@ -1,0 +1,133 @@
+use graph_challenge::graph_vec::Graph;
+use std::fs;
+
+#[test]
+fn test_add_and_remove_vertex() {
+    let mut g = Graph::new();
+    g.add_vertex(1);
+    assert!(g.adjacency.contains_key(&1));
+    g.remove_vertex(1);
+    assert!(!g.adjacency.contains_key(&1));
+}
+
+#[test]
+fn test_add_and_remove_edge() {
+    let mut g = Graph::new();
+    g.add_edge(1, 2, 5.0);
+    assert_eq!(g.get_edge_weight(1, 2), Some(5.0));
+    g.remove_edge(1, 2);
+    assert_eq!(g.get_edge_weight(1, 2), None);
+}
+
+#[test]
+fn test_neighbors() {
+    let mut g = Graph::new();
+    g.add_edge(1, 2, 3.0);
+    g.add_edge(1, 3, 7.0);
+    let neighbors = g.neighbors(1).unwrap();
+    assert_eq!(neighbors.iter().find(|(v, _)| v == &2), Some(&(2, 3.0)));
+    assert_eq!(neighbors.iter().find(|(v, _)| v == &3), Some(&(3, 7.0)));
+}
+
+#[test]
+fn test_persistence() {
+    let mut g = Graph::new();
+    g.add_edge(1, 2, 4.5);
+    let path = "test_graph.bin";
+    g.save_to_file(path).unwrap();
+    let loaded = Graph::load_from_file(path).unwrap();
+    assert_eq!(g.adjacency, loaded.adjacency);
+    fs::remove_file(path).unwrap();
+}
+
+#[test]
+fn test_shortest_path() {
+    let mut g = Graph::new();
+    g.add_edge(1, 2, 1.0);
+    g.add_edge(2, 3, 2.0);
+    g.add_edge(1, 4, 4.0);
+    g.add_edge(4, 3, 1.0);
+    let (path, cost) = g.shortest_path(1, 3).unwrap();
+    assert_eq!(path, vec![1, 2, 3]);
+    assert_eq!(cost, 3.0);
+    assert!(g.shortest_path(3, 1).is_none());
+}
+
+#[test]
+fn test_weighted_shortest_path() {
+    let mut g = Graph::new();
+    g.add_edge(1, 2, 5.0);
+    g.add_edge(2, 3, 2.0);
+    g.add_edge(1, 3, 10.0);
+    let (path, cost) = g.shortest_path(1, 3).unwrap();
+    assert_eq!(path, vec![1, 2, 3]);
+    assert_eq!(cost, 7.0);
+}
+
+#[test]
+fn test_complex_shortest_path() {
+    let mut g = Graph::new();
+    // Create a more complex graph with multiple possible paths
+    g.add_edge(1, 2, 4.0);
+    g.add_edge(2, 3, 2.0);
+    g.add_edge(3, 4, 3.0);
+    g.add_edge(4, 5, 1.0);
+    g.add_edge(1, 6, 2.0);
+    g.add_edge(6, 7, 5.0);
+    g.add_edge(7, 5, 3.0);
+    g.add_edge(1, 8, 6.0);
+    g.add_edge(8, 5, 4.0);
+    g.add_edge(2, 7, 3.0);
+    g.add_edge(3, 8, 5.0);
+
+    // Test shortest path from 1 to 5
+    // Path options:
+    // 1 -> 6 -> 7 -> 5 = 2 + 5 + 3 = 10
+    // 1 -> 2 -> 7 -> 5 = 4 + 3 + 3 = 10
+    // 1 -> 8 -> 5 = 6 + 4 = 10
+    // 1 -> 2 -> 3 -> 4 -> 5 = 4 + 2 + 3 + 1 = 10
+    let (path1, cost1) = g.shortest_path(1, 5).unwrap();
+    // The algorithm found [1, 8, 5] which is correct (cost = 10)
+    assert_eq!(cost1, 10.0);
+    assert!(path1.len() >= 2);
+
+    // Test shortest path from 1 to 8
+    let (path2, cost2) = g.shortest_path(1, 8).unwrap();
+    assert_eq!(path2, vec![1, 8]);
+    assert_eq!(cost2, 6.0);
+
+    // Test shortest path from 2 to 5
+    let (path3, cost3) = g.shortest_path(2, 5).unwrap();
+    assert_eq!(path3, vec![2, 7, 5]);
+    assert_eq!(cost3, 6.0);
+
+    // Test non-existent path
+    assert!(g.shortest_path(5, 1).is_none());
+}
+
+#[test]
+fn test_unweighted_edge() {
+    let mut g = Graph::new();
+    g.add_unweighted_edge(1, 2);
+    assert_eq!(g.get_edge_weight(1, 2), Some(1.0));
+}
+
+#[test]
+fn test_random_connected_graph() {
+    let graph = Graph::random_connected_graph(10, 5, 1.0, 10.0, Some(1));
+
+    // Check that we have the right number of vertices
+    assert_eq!(graph.adjacency.len(), 10);
+
+    // Count edges (should be at least 9 for connectivity + 5 additional)
+    let edge_count: usize = graph
+        .adjacency
+        .values()
+        .map(|neighbors| neighbors.len())
+        .sum();
+    assert!(edge_count >= 14); // 9 for spanning tree + 5 additional
+
+    // Check connectivity by ensuring there's a path from 0 to 9
+    let (path, _cost) = graph.shortest_path(0, 9).unwrap();
+    assert!(!path.is_empty());
+}


### PR DESCRIPTION
## Summary

There are 3 variations of a graph:
- Original graph
- `Vec`-backed graph. The adjacency list stores a sorted `Vec<(u64, f64)>` (sorted by `u64`) instead of a `HashMap<u64, f64>` for each entry
- Memmap-backed graph. The entire graph is backed by a file

Implementing a memmap-backed graph required changes to the serialization format. The format now stores (each point is a `u64`, in order):
- Vertex count
- For each vertex (sorted by vertex ID):
  - Vertex ID
  - Neighbor count
  - Byte offset into file storing neighbor information
- For each neighborhood (sorted by parent vertex ID)
  - Neighbor ID
  - Cost

Random-generation also uses a seeded pseudo-RNG instead of a regular RNG for reproducibility (this can be disabled)

## Optimizations

Attempts to add SIMD to shortest path search didn't seem fruitful - there is potentially already auto-vectorization happening. Parallelization didn't seem worth the effort because of the performance overhead of managing threads/message passing. There are probably still improvements there but a different approach was implemented - nested `HashMap`s were removed and replaced with sorted `Vec`s

When looking up the cost for an edge, the adjacency list is used to look up a `Vec` of neighbors and costs, and binary search is performed on the neighbor IDs. This yielded a performance improvement of ~20% for random-generation benchmarks. This is likely due to codegen/cache friendliness/removing hashing costs

Additionally, the shortest-path search only makes use of 1 `HashMap` instead of 2. When combined with a `Vec`-backed graph, shortest path search seems to improve by ~20%

Results can be reproduced by checking out specific commits and running `cargo bench`

## Features

The addition of a memory-mapped graph now allows graph traversal to be done without loading it into memory. Partial updates were added in the form of edge cost updates. This was the only obvious update that would not break the file schema

## Future

To add Async/IO, `io_uring` could be used to back the IO reads of a memmap-backed graph. This wasn't implemented, but an instantiated graph could have an `IoUring` instance associated with it, and then some form of buffered reading/polling with `Read` opcodes sent to the submission queue