### PR TITLE
@monoid's parallel shortst path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,3 @@ quickcheck_macros = "1.1.0"
 [[bench]]
 name = "graph_bench"
 harness = false
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2024"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 rand = "0.8"
+dary_heap = "0.3.7"
+nohash-hasher = "0.2.0"
+rustc-hash = "2.1.1"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ rustc-hash = "2.1.1"
 
 [dev-dependencies]
 criterion = "0.5"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.1.0"
 
 [[bench]]
 name = "graph_bench"

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,75 @@
+# Report
+
+## Base version improvements
+
+Single-thread version was improved in the following ways:
+
+1. Instead of std's binary heap, `dary_heap::QuaternaryHeap` was used.  It
+   utilises cache better, and gives significant performance for
+   `Graph::shortest_path`.
+2. `Graph::adjacency` uses a hashmap with much simpler hasher from crate
+   `nohash_hasher`.  `rustc-hash` can also be used, but its speedup is not as
+   large.  It improves both `Graph::random_connected_graph` and
+   `Graph::shortest_path`.
+3. Presuming that vertex IDs are in range 0..n, vectors are used to store
+   weights and previous vertex index.
+
+   We may reorganize the API, keep an `bimap` table to keep a correspondence
+   between arbitrary vertex IDs and positions, or just require that the IDs
+   cannot be sparse.
+
+|                                             | old       | new       |         |
+|---------------------------------------------|-----------|-----------|---------|
+|shortest path on random connected graph, ARM | 3.4230 µs | 1.1198 µs | -67.452%|
+| -// -, x64                                  | 6.3577 µs | 1.9425 µs | -69.664%|
+|generate random connected graph, ARM         | 18.312 µs | 10.796 µs | -41.080%|
+| -//-, x64                                   | 24.573 µs | 14.935 µs | -39.254%|
+
+(ARM: MacOS M1, x64: Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70GHz at DigitalOcean).
+
+## Parallel version
+
+The parallel version consists of `threads` workers each having own priority
+queue (the very same `dary_heap::QuaternaryHeap`).  They share the same
+read-only `Graph` instance, and also `costs` (i.e. `dist`), a slice of custom
+`&[AtomicF64]` type, `prev` of `&[AtomicIsize]`, and `locks` of `&[AtomicBool]`
+for coordinated update of the two formers.
+
+The idea of working with these values is:
+
+1. Reading atomically an element of `costs` with relaxed ordering is safe
+   because the cost is never increasing.  If we get a stale value, worst thing
+   that would happen is trying to lock one of the `locks` only to found that
+   actual value is smaller.  But it is a rare event.
+2. Reading of `prev` only happens after all the threads are finished their work.
+   Updating `prev` is done together with `costs` under lock `locks[i]` that
+   induce "happens before" for both fields.
+
+The workers's queues are also guarded by an `AtomicBool`, but most of the time
+they do work with own data uncontended.  However, when a worker has no work, it
+tries to steal some work from other worker, locking on his queue, in round-robin
+fashion (it also happens at start: only the main thread gets a seed value).
+
+When a worker runs out of work, it increases an atomic `waitings` counter. When
+the counter is equal to number of threads, all the threads except the main one,
+terminate.
+
+### Benchmarking parallel version
+
+Parallel version makes sense only on larger graph; unfortunately, large graph's
+search time varies greatly depending on graph's structure. To mitigate this
+problem, 5 random graphs are generated, and each implementation is run on all of
+them.
+
+|                | ARM        | x64       |
+|----------------|------------|-----------|
+| seq-5x         | 199.76 ms  | 455.39 ms |
+| par-5x         | 113.67 ms  | 308.58 ms |
+| speedup        | 1.7        | 1.47      |
+| efficiency     | 0.43       | 0.38      |
+
+(ARM: MacOS M1, x64: Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70GHz at DigitalOcean).
+
+The efficiency is way below 1 is not only because of synchronization costs, but
+because threads, having the priority queue split, do calculations for suboptimal paths
+too. But it is still faster overall.

--- a/benches/graph_bench.rs
+++ b/benches/graph_bench.rs
@@ -22,4 +22,4 @@ criterion_group!(benches,
     bench_shortest_path,
     bench_graph_generation
 );
-criterion_main!(benches); 
+criterion_main!(benches);

--- a/benches/graph_bench.rs
+++ b/benches/graph_bench.rs
@@ -1,17 +1,20 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use graph_challenge::graph::Graph;
 
-const BENCH_SIZE: u64 = 900000;
-const THREADS: usize = 6;
+const BENCH_SIZE: u64 = 400000;
+const THREADS: usize = 4;
 
 fn bench_shortest_path(c: &mut Criterion) {
+    use rand::SeedableRng;
     // avaraging  on multiple graphs
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+
     let graphs = vec![
-        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
-        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
-        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
-        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
-        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
+        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
+        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
+        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
+        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
+        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
     ];
     let mut b = c.benchmark_group("shortest path on random connected graph");
     for mode in ["seq", "full", "parallel"] {
@@ -20,20 +23,34 @@ fn bench_shortest_path(c: &mut Criterion) {
             mode,
             |b, mode| match mode {
                 "seq" => {
-                    for g in &graphs {
-                        b.iter(|| g.shortest_path(0, BENCH_SIZE - 1));
-                    }
+                    b.iter(|| {
+                        (
+                            graphs[0].shortest_path(0, BENCH_SIZE - 1),
+                            graphs[1].shortest_path(0, BENCH_SIZE - 1),
+                            graphs[2].shortest_path(0, BENCH_SIZE - 1),
+                            graphs[3].shortest_path(0, BENCH_SIZE - 1),
+                            graphs[4].shortest_path(0, BENCH_SIZE - 1),
+                        )
+                    });
                 }
-                "full" => {
-                    for g in &graphs {
-                        b.iter(|| g.shortest_path_full(0, BENCH_SIZE - 1))
-                    }
-                }
-                "parallel" => {
-                    for g in &graphs {
-                        b.iter(|| g.parallel_shortest_path(0, BENCH_SIZE - 1, THREADS))
-                    }
-                }
+                "full" => b.iter(|| {
+                    (
+                        graphs[0].shortest_path_full(0, BENCH_SIZE - 1),
+                        graphs[1].shortest_path_full(0, BENCH_SIZE - 1),
+                        graphs[2].shortest_path_full(0, BENCH_SIZE - 1),
+                        graphs[3].shortest_path_full(0, BENCH_SIZE - 1),
+                        graphs[4].shortest_path_full(0, BENCH_SIZE - 1),
+                    )
+                }),
+                "parallel" => b.iter(|| {
+                    (
+                        graphs[0].parallel_shortest_path(0, BENCH_SIZE - 1, THREADS),
+                        graphs[1].parallel_shortest_path(0, BENCH_SIZE - 1, THREADS),
+                        graphs[2].parallel_shortest_path(0, BENCH_SIZE - 1, THREADS),
+                        graphs[3].parallel_shortest_path(0, BENCH_SIZE - 1, THREADS),
+                        graphs[4].parallel_shortest_path(0, BENCH_SIZE - 1, THREADS),
+                    )
+                }),
                 _ => unreachable!(),
             },
         );

--- a/benches/graph_bench.rs
+++ b/benches/graph_bench.rs
@@ -5,6 +5,15 @@ const BENCH_SIZE: u64 = 400000;
 const THREADS: usize = 4;
 
 fn bench_shortest_path(c: &mut Criterion) {
+    let g = Graph::random_connected_graph(100, 50, 1.0, 10.0);
+    c.bench_function("shortest path on random connected graph", |b| {
+        b.iter(|| {
+            g.shortest_path(0, 99);
+        })
+    });
+}
+
+fn bench_compare_5x(c: &mut Criterion) {
     use rand::SeedableRng;
     // avaraging  on multiple graphs
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -16,8 +25,8 @@ fn bench_shortest_path(c: &mut Criterion) {
         Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
         Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
     ];
-    let mut b = c.benchmark_group("shortest path on random connected graph");
-    for mode in ["seq", "full", "parallel"] {
+    let mut b = c.benchmark_group("compare implementations on 5 random graphs");
+    for mode in ["seq", "parallel"] {
         b.bench_with_input(
             BenchmarkId::from_parameter(mode),
             mode,
@@ -33,15 +42,6 @@ fn bench_shortest_path(c: &mut Criterion) {
                         )
                     });
                 }
-                "full" => b.iter(|| {
-                    (
-                        graphs[0].shortest_path_full(0, BENCH_SIZE - 1),
-                        graphs[1].shortest_path_full(0, BENCH_SIZE - 1),
-                        graphs[2].shortest_path_full(0, BENCH_SIZE - 1),
-                        graphs[3].shortest_path_full(0, BENCH_SIZE - 1),
-                        graphs[4].shortest_path_full(0, BENCH_SIZE - 1),
-                    )
-                }),
                 "parallel" => b.iter(|| {
                     (
                         graphs[0].parallel_shortest_path(0, BENCH_SIZE - 1, THREADS),
@@ -65,5 +65,5 @@ fn bench_graph_generation(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_shortest_path, bench_graph_generation);
+criterion_group!(benches, bench_shortest_path, bench_compare_5x, bench_graph_generation);
 criterion_main!(benches);

--- a/benches/graph_bench.rs
+++ b/benches/graph_bench.rs
@@ -19,11 +19,41 @@ fn bench_compare_5x(c: &mut Criterion) {
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
     let graphs = vec![
-        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
-        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
-        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
-        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
-        Graph::random_connected_graph_with_rng(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0, &mut rng),
+        Graph::random_connected_graph_with_rng(
+            BENCH_SIZE,
+            BENCH_SIZE as usize / 100,
+            1.0,
+            10.0,
+            &mut rng,
+        ),
+        Graph::random_connected_graph_with_rng(
+            BENCH_SIZE,
+            BENCH_SIZE as usize / 100,
+            1.0,
+            10.0,
+            &mut rng,
+        ),
+        Graph::random_connected_graph_with_rng(
+            BENCH_SIZE,
+            BENCH_SIZE as usize / 100,
+            1.0,
+            10.0,
+            &mut rng,
+        ),
+        Graph::random_connected_graph_with_rng(
+            BENCH_SIZE,
+            BENCH_SIZE as usize / 100,
+            1.0,
+            10.0,
+            &mut rng,
+        ),
+        Graph::random_connected_graph_with_rng(
+            BENCH_SIZE,
+            BENCH_SIZE as usize / 100,
+            1.0,
+            10.0,
+            &mut rng,
+        ),
     ];
     let mut b = c.benchmark_group("compare implementations on 5 random graphs");
     for mode in ["seq", "parallel"] {
@@ -65,5 +95,10 @@ fn bench_graph_generation(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_shortest_path, bench_compare_5x, bench_graph_generation);
+criterion_group!(
+    benches,
+    bench_shortest_path,
+    bench_compare_5x,
+    bench_graph_generation
+);
 criterion_main!(benches);

--- a/benches/graph_bench.rs
+++ b/benches/graph_bench.rs
@@ -1,13 +1,43 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use graph_challenge::graph::Graph;
 
+const BENCH_SIZE: u64 = 900000;
+const THREADS: usize = 6;
+
 fn bench_shortest_path(c: &mut Criterion) {
-    let g = Graph::random_connected_graph(100, 50, 1.0, 10.0);
-    c.bench_function("shortest path on random connected graph", |b| {
-        b.iter(|| {
-            g.shortest_path(0, 99);
-        })
-    });
+    // avaraging  on multiple graphs
+    let graphs = vec![
+        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
+        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
+        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
+        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
+        Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0),
+    ];
+    let mut b = c.benchmark_group("shortest path on random connected graph");
+    for mode in ["seq", "full", "parallel"] {
+        b.bench_with_input(
+            BenchmarkId::from_parameter(mode),
+            mode,
+            |b, mode| match mode {
+                "seq" => {
+                    for g in &graphs {
+                        b.iter(|| g.shortest_path(0, BENCH_SIZE - 1));
+                    }
+                }
+                "full" => {
+                    for g in &graphs {
+                        b.iter(|| g.shortest_path_full(0, BENCH_SIZE - 1))
+                    }
+                }
+                "parallel" => {
+                    for g in &graphs {
+                        b.iter(|| g.parallel_shortest_path(0, BENCH_SIZE - 1, THREADS))
+                    }
+                }
+                _ => unreachable!(),
+            },
+        );
+    }
 }
 
 fn bench_graph_generation(c: &mut Criterion) {
@@ -18,8 +48,5 @@ fn bench_graph_generation(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, 
-    bench_shortest_path,
-    bench_graph_generation
-);
+criterion_group!(benches, bench_shortest_path, bench_graph_generation);
 criterion_main!(benches);

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,10 +1,24 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::{
+    cell::UnsafeCell,
+    hint::spin_loop,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
 
+/// A lock guard for an atomic boolean lock.
+///
+/// The lock is locked when the boolean is `true` and unlocked when it is `false`.
+///
+/// Dropping the `AtomicLockGuard` will automatically unlock the lock.
 pub struct AtomicLockGuard<'atomic> {
     lock: &'atomic AtomicBool,
 }
 
 impl<'atomic> AtomicLockGuard<'atomic> {
+    /// Creates a new `AtomicLockGuard` by locking the provided atomic boolean.
+    ///
+    /// It will wait indefinitely until the lock can be acquired.
+    #[inline]
     pub fn lock(lock: &'atomic AtomicBool) -> Self {
         Self::do_lock(lock);
         Self { lock }
@@ -12,38 +26,128 @@ impl<'atomic> AtomicLockGuard<'atomic> {
 
     fn do_lock(lock: &'atomic AtomicBool) {
         while lock.swap(true, Ordering::Acquire) {
-            std::hint::spin_loop();
+            spin_loop();
         }
     }
 
+    #[inline]
     fn unlock(&self) {
         self.lock.store(false, Ordering::Release);
     }
 }
 
 impl Drop for AtomicLockGuard<'_> {
+    #[inline]
     fn drop(&mut self) {
         self.unlock();
     }
 }
 
+/// An atomic floating-point type that provides atomic load and store-related operations on `f64` values.
+#[derive(Debug)]
+#[repr(transparent)]
 pub(crate) struct AtomicF64(AtomicU64);
 
 impl AtomicF64 {
+    #[inline]
     pub fn new(value: f64) -> Self {
         Self(AtomicU64::new(value.to_bits()))
     }
 
+    #[inline]
     pub fn load(&self, order: Ordering) -> f64 {
         f64::from_bits(self.0.load(order))
     }
 
+    #[inline]
     pub fn store(&self, value: f64, order: Ordering) {
         self.0.store(value.to_bits(), order);
     }
 
-    pub fn swap(&self, value: f64, order: Ordering) -> f64 {
-        f64::from_bits(self.0.swap(value.to_bits(), order))
+}
+
+pub(crate) struct AtomicSemaphoreGuard<'atomic> {
+    lock: &'atomic AtomicU64,
+    drop_order: Ordering,
+}
+
+impl<'atomic> AtomicSemaphoreGuard<'atomic> {
+    #[inline]
+    pub fn increment(lock: &'atomic AtomicU64, order: Ordering, drop_order: Ordering) -> Self {
+        lock.fetch_add(1, order);
+        Self { lock, drop_order }
+    }
+}
+
+impl<'atomic> Drop for AtomicSemaphoreGuard<'atomic> {
+    #[inline]
+    fn drop(&mut self) {
+        self.lock.fetch_sub(1, self.drop_order);
+    }
+}
+pub struct AtomicMutex<T> {
+    value: UnsafeCell<T>,
+    atomlock: AtomicBool,
+}
+
+unsafe impl<T: Send> Send for AtomicMutex<T> {}
+
+unsafe impl<T: Send> Sync for AtomicMutex<T> {}
+
+pub struct AtomicMutexGuard<'a, T> {
+    parent: &'a AtomicMutex<T>,
+}
+
+impl<T> AtomicMutex<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            value: UnsafeCell::<T>::new(value),
+            atomlock: AtomicBool::new(false),
+        }
+    }
+
+    pub fn lock(&self) -> AtomicMutexGuard<'_, T> {
+        while self.atomlock.swap(true, Ordering::AcqRel) {
+            spin_loop()
+        }
+        AtomicMutexGuard { parent: self }
+    }
+
+    pub fn try_lock(&self) -> Option<AtomicMutexGuard<'_, T>> {
+        if !self.atomlock.swap(true, Ordering::AcqRel) {
+            Some(AtomicMutexGuard { parent: self })
+        } else {
+            None
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for AtomicMutex<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let guard = self.lock();
+        f.debug_struct("AtomicMutex")
+            .field("value", &*guard)
+            .finish()
+    }
+}
+
+impl<T> Drop for AtomicMutexGuard<'_, T> {
+    fn drop(&mut self) {
+        self.parent.atomlock.store(false, Ordering::Release);
+    }
+}
+
+impl<T> Deref for AtomicMutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.parent.value.get() }
+    }
+}
+
+impl<T> DerefMut for AtomicMutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.parent.value.get() }
     }
 }
 
@@ -69,9 +173,26 @@ mod tests {
         atomic_f64.store(2.71, Ordering::Relaxed);
         assert_eq!(atomic_f64.load(Ordering::Relaxed), 2.71);
 
-        let old_value = atomic_f64.swap(42, Ordering::Relaxed);
+        let old_value = atomic_f64.swap(42.0, Ordering::Relaxed);
         assert_eq!(old_value, 2.71);
 
-        assert_eq!(atomic_f64.load(Ordering::Relaxed), 42);
+        assert_eq!(atomic_f64.load(Ordering::Relaxed), 42.0);
+    }
+
+    #[test]
+    fn test_atomic_semaphore_guard_smoke() {
+        let lock = AtomicU64::new(0);
+        {
+            let _guard1 =
+                AtomicSemaphoreGuard::increment(&lock, Ordering::Relaxed, Ordering::Relaxed);
+            assert_eq!(lock.load(Ordering::Relaxed), 1);
+            {
+                let _guard2 =
+                    AtomicSemaphoreGuard::increment(&lock, Ordering::Relaxed, Ordering::Relaxed);
+                assert_eq!(lock.load(Ordering::Relaxed), 2);
+            }
+            assert_eq!(lock.load(Ordering::Relaxed), 1);
+        }
+        assert_eq!(lock.load(Ordering::Relaxed), 0);
     }
 }

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,0 +1,77 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+pub struct AtomicLockGuard<'atomic> {
+    lock: &'atomic AtomicBool,
+}
+
+impl<'atomic> AtomicLockGuard<'atomic> {
+    pub fn lock(lock: &'atomic AtomicBool) -> Self {
+        Self::do_lock(lock);
+        Self { lock }
+    }
+
+    fn do_lock(lock: &'atomic AtomicBool) {
+        while lock.swap(true, Ordering::Acquire) {
+            std::hint::spin_loop();
+        }
+    }
+
+    fn unlock(&self) {
+        self.lock.store(false, Ordering::Release);
+    }
+}
+
+impl Drop for AtomicLockGuard<'_> {
+    fn drop(&mut self) {
+        self.unlock();
+    }
+}
+
+pub(crate) struct AtomicF64(AtomicU64);
+
+impl AtomicF64 {
+    pub fn new(value: f64) -> Self {
+        Self(AtomicU64::new(value.to_bits()))
+    }
+
+    pub fn load(&self, order: Ordering) -> f64 {
+        f64::from_bits(self.0.load(order))
+    }
+
+    pub fn store(&self, value: f64, order: Ordering) {
+        self.0.store(value.to_bits(), order);
+    }
+
+    pub fn swap(&self, value: f64, order: Ordering) -> f64 {
+        f64::from_bits(self.0.swap(value.to_bits(), order))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_atomic_lock_smoke() {
+        let lock = std::sync::atomic::AtomicBool::new(false);
+        {
+            let _guard = AtomicLockGuard::lock(&lock);
+            assert!(lock.load(std::sync::atomic::Ordering::Relaxed));
+        }
+        assert!(!lock.load(std::sync::atomic::Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_atomic_f64_smoke() {
+        let atomic_f64 = AtomicF64::new(3.14);
+        assert_eq!(atomic_f64.load(Ordering::Relaxed), 3.14);
+
+        atomic_f64.store(2.71, Ordering::Relaxed);
+        assert_eq!(atomic_f64.load(Ordering::Relaxed), 2.71);
+
+        let old_value = atomic_f64.swap(42, Ordering::Relaxed);
+        assert_eq!(old_value, 2.71);
+
+        assert_eq!(atomic_f64.load(Ordering::Relaxed), 42);
+    }
+}

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -172,11 +172,6 @@ mod tests {
 
         atomic_f64.store(2.71, Ordering::Relaxed);
         assert_eq!(atomic_f64.load(Ordering::Relaxed), 2.71);
-
-        let old_value = atomic_f64.swap(42.0, Ordering::Relaxed);
-        assert_eq!(old_value, 2.71);
-
-        assert_eq!(atomic_f64.load(Ordering::Relaxed), 42.0);
     }
 
     #[test]

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -63,7 +63,6 @@ impl AtomicF64 {
     pub fn store(&self, value: f64, order: Ordering) {
         self.0.store(value.to_bits(), order);
     }
-
 }
 
 pub(crate) struct AtomicSemaphoreGuard<'atomic> {

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -122,15 +122,6 @@ impl<T> AtomicMutex<T> {
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for AtomicMutex<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let guard = self.lock();
-        f.debug_struct("AtomicMutex")
-            .field("value", &*guard)
-            .finish()
-    }
-}
-
 impl<T> Drop for AtomicMutexGuard<'_, T> {
     fn drop(&mut self) {
         self.parent.atomlock.store(false, Ordering::Release);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -38,6 +38,12 @@ impl Graph {
         <_>::default()
     }
 
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            adjacency: TheMap::with_capacity_and_hasher(capacity, <_>::default()),
+        }
+    }
+
     pub fn add_vertex(&mut self, v: u64) {
         self.adjacency.entry(v).or_default();
     }
@@ -227,7 +233,7 @@ impl Graph {
         max_weight: f64,
         rng: &mut Rng,
     ) -> Self {
-        let mut graph = Graph::new();
+        let mut graph = Graph::with_capacity(num_vertices as usize);
 
         // Add all vertices first
         for i in 0..num_vertices {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -92,11 +92,11 @@ impl Graph {
             return None;
         }
 
-        // TODO single hashmap
-        let mut dist = vec![(f64::INFINITY, None); self.adjacency.len() + 1];
+        let mut dist = vec![f64::INFINITY; self.adjacency.len() + 1];
+        let mut prev = vec![None; self.adjacency.len() + 1];
         let mut heap = TheHeap::new();
 
-        dist[start as usize] = (0.0, None);
+        dist[start as usize] = 0.0;
         heap.push(State {
             cost: 0.0,
             position: start,
@@ -106,7 +106,7 @@ impl Graph {
             if position == end {
                 let mut path = vec![end];
                 let mut current = end;
-                while let Some(&p) = dist[current as usize].1.as_ref() {
+                while let Some(p) = prev[current as usize] {
                     path.push(p);
                     current = p;
                 }
@@ -114,7 +114,7 @@ impl Graph {
                 return Some((path, cost));
             }
 
-            if cost > dist[position as usize].0 {
+            if cost > dist[position as usize] {
                 continue;
             }
 
@@ -124,8 +124,9 @@ impl Graph {
                         cost: cost + weight,
                         position: neighbor,
                     };
-                    if next.cost < dist[neighbor as usize].0 {
-                        dist[neighbor as usize] = (next.cost, Some(position));
+                    if next.cost < dist[neighbor as usize] {
+                        dist[neighbor as usize] = next.cost;
+                        prev[neighbor as usize] = Some(position);
                         heap.push(next);
                     }
                 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -211,8 +211,24 @@ impl Graph {
         min_weight: f64,
         max_weight: f64,
     ) -> Self {
-        let mut graph = Graph::new();
         let mut rng = rand::thread_rng();
+        Self::random_connected_graph_with_rng(
+            num_vertices,
+            additional_edges,
+            min_weight,
+            max_weight,
+            &mut rng,
+        )
+    }
+
+    pub fn random_connected_graph_with_rng<Rng: rand::Rng>(
+        num_vertices: u64,
+        additional_edges: usize,
+        min_weight: f64,
+        max_weight: f64,
+        rng: &mut Rng,
+    ) -> Self {
+        let mut graph = Graph::new();
 
         // Add all vertices first
         for i in 0..num_vertices {
@@ -257,7 +273,7 @@ impl Graph {
             return None;
         }
 
-        let search = self::worker::Search::new(self, start);
+        let search = self::worker::Search::new(self, start, end);
         let workers = (0..threads)
             .map(|_| self::worker::Worker::new())
             .collect::<Vec<_>>();
@@ -276,7 +292,7 @@ impl Graph {
                     // );
                 });
             }
-            search.start_work(0, &workers[..], start);
+            search.start_work(0, &workers[..]);
         });
 
         if search.prev[end as usize].load(Ordering::Relaxed) == -1 {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,19 +1,13 @@
+pub(crate) mod worker;
+
+use rand::Rng;
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter};
-use serde::{Serialize, Deserialize};
-use rand::Rng;
 
 use dary_heap::QuaternaryHeap as TheHeap;
-// use std::collections::BinaryHeap as TheHeap;
-
 use nohash_hasher::IntMap as TheMap;
-// use rustc_hash::FxHashMap as TheMap;
-// use std::collections::HashMap as TheMap;
-
-// use nohash_hasher::IntMap as SecMap;
-// use std::collections::HashMap as SecMap;
-use rustc_hash::FxHashMap as SecMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Graph {
@@ -93,18 +87,15 @@ impl Graph {
             return None;
         }
 
-        // let mut dist = SecMap::<u64, f64>::with_capacity(self.adjacency.len());
-        // let mut prev = SecMap::<u64, u64>::with_capacity(self.adjacency.len());
-
-        // let mut dist = SecMap::<u64, f64>::with_capacity_and_hasher(self.adjacency.len(), <_>::default());
-        // let mut prev = SecMap::<u64, u64>::with_capacity_and_hasher(self.adjacency.len(), <_>::default());
-
         // TODO single hashmap
-        let mut dist = vec![(f64::INFINITY, None); self.adjacency.len()];
+        let mut dist = vec![(f64::INFINITY, None); self.adjacency.len() + 1];
         let mut heap = TheHeap::new();
 
         dist[start as usize] = (0.0, None);
-        heap.push(State { cost: 0.0, position: start });
+        heap.push(State {
+            cost: 0.0,
+            position: start,
+        });
 
         while let Some(State { cost, position }) = heap.pop() {
             if position == end {
@@ -124,7 +115,10 @@ impl Graph {
 
             if let Some(neighbors) = self.adjacency.get(&position) {
                 for (&neighbor, &weight) in neighbors {
-                    let next = State { cost: cost + weight, position: neighbor };
+                    let next = State {
+                        cost: cost + weight,
+                        position: neighbor,
+                    };
                     if next.cost < dist[neighbor as usize].0 {
                         dist[neighbor as usize] = (next.cost, Some(position));
                         heap.push(next);
@@ -136,46 +130,111 @@ impl Graph {
         None
     }
 
+    pub fn shortest_path_full(&self, start: u64, end: u64) -> Option<(Vec<u64>, f64)> {
+        // TODO more compact vec-based implementation.
+        //
+        // questions:
+        // 1. [x] can I change public fields?  YES, BACKWARD COMPATIBILITY NOT NEEDED
+        // 2. do I need to handle negative/NaN weights?
+        // 3. the examples use sequential node ids, can I rely on non-sparce node ids?
+        if !self.adjacency.contains_key(&start) || !self.adjacency.contains_key(&end) {
+            return None;
+        }
+
+        // let mut dist = SecMap::<u64, f64>::with_capacity(self.adjacency.len());
+        // let mut prev = SecMap::<u64, u64>::with_capacity(self.adjacency.len());
+
+        // let mut dist = SecMap::<u64, f64>::with_capacity_and_hasher(self.adjacency.len(), <_>::default());
+        // let mut prev = SecMap::<u64, u64>::with_capacity_and_hasher(self.adjacency.len(), <_>::default());
+
+        // TODO single hashmap
+        let mut dist = vec![(f64::INFINITY, None); self.adjacency.len() + 1];
+        let mut heap = TheHeap::new();
+
+        dist[start as usize] = (0.0, None);
+        heap.push(State {
+            cost: 0.0,
+            position: start,
+        });
+
+        while let Some(State { cost, position }) = heap.pop() {
+            if cost > dist[position as usize].0 {
+                continue;
+            }
+
+            if let Some(neighbors) = self.adjacency.get(&position) {
+                for (&neighbor, &weight) in neighbors {
+                    let next = State {
+                        cost: cost + weight,
+                        position: neighbor,
+                    };
+                    if next.cost < dist[neighbor as usize].0 {
+                        dist[neighbor as usize] = (next.cost, Some(position));
+                        heap.push(next);
+                    }
+                }
+            }
+        }
+
+        if dist[end as usize].0 == f64::INFINITY {
+            None
+        } else {
+            let mut path = vec![end];
+            let mut current = end;
+            while let Some(&p) = dist[current as usize].1.as_ref() {
+                path.push(p);
+                current = p;
+            }
+            path.reverse();
+            Some((path, dist[end as usize].0))
+        }
+    }
+
     // For backward compatibility with unweighted graphs
     pub fn add_unweighted_edge(&mut self, from: u64, to: u64) {
         self.add_edge(from, to, 1.0);
     }
 
     /// Generate a random connected graph with specified number of vertices
-    /// 
+    ///
     /// # Arguments
     /// * `num_vertices` - Number of vertices in the graph
     /// * `additional_edges` - Additional random edges beyond the minimum for connectivity
     /// * `min_weight` - Minimum edge weight (inclusive)
     /// * `max_weight` - Maximum edge weight (exclusive)
-    /// 
+    ///
     /// # Returns
     /// A new connected Graph with random edges
-    pub fn random_connected_graph(num_vertices: u64, additional_edges: usize, min_weight: f64, max_weight: f64) -> Self {
+    pub fn random_connected_graph(
+        num_vertices: u64,
+        additional_edges: usize,
+        min_weight: f64,
+        max_weight: f64,
+    ) -> Self {
         let mut graph = Graph::new();
         let mut rng = rand::thread_rng();
-        
+
         // Add all vertices first
         for i in 0..num_vertices {
             graph.add_vertex(i);
         }
-        
+
         // Create a spanning tree to ensure connectivity
         for i in 1..num_vertices {
             let parent = rng.gen_range(0..i);
             let weight = rng.gen_range(min_weight..max_weight);
             graph.add_edge(parent, i, weight);
         }
-        
+
         // Add additional random edges
         let mut edges_added = 0;
         let max_attempts = additional_edges * 10;
         let mut attempts = 0;
-        
+
         while edges_added < additional_edges && attempts < max_attempts {
             let from = rng.gen_range(0..num_vertices);
             let to = rng.gen_range(0..num_vertices);
-            
+
             if from != to && graph.get_edge_weight(from, to).is_none() {
                 let weight = rng.gen_range(min_weight..max_weight);
                 graph.add_edge(from, to, weight);
@@ -183,7 +242,56 @@ impl Graph {
             }
             attempts += 1;
         }
-        
+
         graph
+    }
+
+    pub fn parallel_shortest_path(
+        &self,
+        start: u64,
+        end: u64,
+        threads: usize,
+    ) -> Option<(Vec<u64>, f64)> {
+        use std::sync::atomic::Ordering;
+        if !self.adjacency.contains_key(&start) || !self.adjacency.contains_key(&end) {
+            return None;
+        }
+
+        let search = self::worker::Search::new(self, start);
+        let workers = (0..threads)
+            .map(|_| self::worker::Worker::new())
+            .collect::<Vec<_>>();
+
+        std::thread::scope(|s| {
+            for id in 1..threads {
+                let workers = &workers[..];
+                let search = &search;
+                s.spawn(move || {
+                    search.run_worker(id, workers);
+                    // let steals = workers[id].steals.load(Ordering::Relaxed);
+                    // let steal_loops = workers[id].steal_loops.load(Ordering::Relaxed);
+                    // eprintln!(
+                    //     "Worker {} finished with {} steals, {} loops",
+                    //     id, steals, steal_loops
+                    // );
+                });
+            }
+            search.start_work(0, &workers[..], start);
+        });
+
+        if search.prev[end as usize].load(Ordering::Relaxed) == -1 {
+            None
+        } else {
+            let mut path = vec![end];
+            let mut prev;
+            while {
+                prev = search.prev[*path.last().unwrap() as usize].load(Ordering::Relaxed);
+                prev >= 0
+            } {
+                path.push(prev as u64);
+            }
+            path.reverse();
+            Some((path, search.costs[end as usize].load(Ordering::Relaxed)))
+        }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -136,66 +136,6 @@ impl Graph {
         None
     }
 
-    pub fn shortest_path_full(&self, start: u64, end: u64) -> Option<(Vec<u64>, f64)> {
-        // TODO more compact vec-based implementation.
-        //
-        // questions:
-        // 1. [x] can I change public fields?  YES, BACKWARD COMPATIBILITY NOT NEEDED
-        // 2. do I need to handle negative/NaN weights?
-        // 3. the examples use sequential node ids, can I rely on non-sparce node ids?
-        if !self.adjacency.contains_key(&start) || !self.adjacency.contains_key(&end) {
-            return None;
-        }
-
-        // let mut dist = SecMap::<u64, f64>::with_capacity(self.adjacency.len());
-        // let mut prev = SecMap::<u64, u64>::with_capacity(self.adjacency.len());
-
-        // let mut dist = SecMap::<u64, f64>::with_capacity_and_hasher(self.adjacency.len(), <_>::default());
-        // let mut prev = SecMap::<u64, u64>::with_capacity_and_hasher(self.adjacency.len(), <_>::default());
-
-        // TODO single hashmap
-        let mut dist = vec![(f64::INFINITY, None); self.adjacency.len() + 1];
-        let mut heap = TheHeap::new();
-
-        dist[start as usize] = (0.0, None);
-        heap.push(State {
-            cost: 0.0,
-            position: start,
-        });
-
-        while let Some(State { cost, position }) = heap.pop() {
-            if cost > dist[position as usize].0 {
-                continue;
-            }
-
-            if let Some(neighbors) = self.adjacency.get(&position) {
-                for (&neighbor, &weight) in neighbors {
-                    let next = State {
-                        cost: cost + weight,
-                        position: neighbor,
-                    };
-                    if next.cost < dist[neighbor as usize].0 {
-                        dist[neighbor as usize] = (next.cost, Some(position));
-                        heap.push(next);
-                    }
-                }
-            }
-        }
-
-        if dist[end as usize].0 == f64::INFINITY {
-            None
-        } else {
-            let mut path = vec![end];
-            let mut current = end;
-            while let Some(&p) = dist[current as usize].1.as_ref() {
-                path.push(p);
-                current = p;
-            }
-            path.reverse();
-            Some((path, dist[end as usize].0))
-        }
-    }
-
     // For backward compatibility with unweighted graphs
     pub fn add_unweighted_edge(&mut self, from: u64, to: u64) {
         self.add_edge(from, to, 1.0);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,5 @@
 pub(crate) mod worker;
 
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fs::File;
@@ -292,7 +291,7 @@ impl Graph {
                     // );
                 });
             }
-            search.start_work(0, &workers[..]);
+            search.run_main_thread(0, &workers[..]);
         });
 
         if search.prev[end as usize].load(Ordering::Relaxed) == -1 {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -278,10 +278,11 @@ impl Graph {
             .collect::<Vec<_>>();
 
         std::thread::scope(|s| {
+            let mut worker_threads = Vec::with_capacity(threads - 1);
             for id in 1..threads {
                 let workers = &workers[..];
                 let search = &search;
-                s.spawn(move || {
+                let worker = s.spawn(move || {
                     search.run_worker(id, workers);
                     // let steals = workers[id].steals.load(Ordering::Relaxed);
                     // let steal_loops = workers[id].steal_loops.load(Ordering::Relaxed);
@@ -290,8 +291,14 @@ impl Graph {
                     //     id, steals, steal_loops
                     // );
                 });
+                worker_threads.push(worker);
             }
             search.run_main_thread(0, &workers[..]);
+
+            // it is a safety measure to detect deadlocks
+            for thread in worker_threads {
+                thread.join().unwrap();
+            }
         });
 
         if search.prev[end as usize].load(Ordering::Relaxed) == -1 {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,4 @@
-pub(crate) mod worker;
+pub(crate) mod parallel_search;
 
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -214,53 +214,11 @@ impl Graph {
         end: u64,
         threads: usize,
     ) -> Option<(Vec<u64>, f64)> {
-        use std::sync::atomic::Ordering;
         if !self.adjacency.contains_key(&start) || !self.adjacency.contains_key(&end) {
             return None;
         }
 
-        let search = self::worker::Search::new(self, start, end);
-        let workers = (0..threads)
-            .map(|_| self::worker::Worker::new())
-            .collect::<Vec<_>>();
-
-        std::thread::scope(|s| {
-            let mut worker_threads = Vec::with_capacity(threads - 1);
-            for id in 1..threads {
-                let workers = &workers[..];
-                let search = &search;
-                let worker = s.spawn(move || {
-                    search.run_worker(id, workers);
-                    // let steals = workers[id].steals.load(Ordering::Relaxed);
-                    // let steal_loops = workers[id].steal_loops.load(Ordering::Relaxed);
-                    // eprintln!(
-                    //     "Worker {} finished with {} steals, {} loops",
-                    //     id, steals, steal_loops
-                    // );
-                });
-                worker_threads.push(worker);
-            }
-            search.run_main_thread(0, &workers[..]);
-
-            // it is a safety measure to detect deadlocks
-            for thread in worker_threads {
-                thread.join().unwrap();
-            }
-        });
-
-        if search.prev[end as usize].load(Ordering::Relaxed) == -1 {
-            None
-        } else {
-            let mut path = vec![end];
-            let mut prev;
-            while {
-                prev = search.prev[*path.last().unwrap() as usize].load(Ordering::Relaxed);
-                prev >= 0
-            } {
-                path.push(prev as u64);
-            }
-            path.reverse();
-            Some((path, search.costs[end as usize].load(Ordering::Relaxed)))
-        }
+        let search = self::parallel_search::Search::new(self, start, end);
+        search.run(threads)
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,13 +1,23 @@
-use std::collections::{HashMap, BinaryHeap};
 use std::cmp::Ordering;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter};
 use serde::{Serialize, Deserialize};
 use rand::Rng;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+use dary_heap::QuaternaryHeap as TheHeap;
+// use std::collections::BinaryHeap as TheHeap;
+
+use nohash_hasher::IntMap as TheMap;
+// use rustc_hash::FxHashMap as TheMap;
+// use std::collections::HashMap as TheMap;
+
+// use nohash_hasher::IntMap as SecMap;
+// use std::collections::HashMap as SecMap;
+use rustc_hash::FxHashMap as SecMap;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Graph {
-    pub adjacency: HashMap<u64, HashMap<u64, f64>>,
+    pub adjacency: TheMap<u64, TheMap<u64, f64>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -32,7 +42,7 @@ impl Ord for State {
 
 impl Graph {
     pub fn new() -> Self {
-        Self { adjacency: HashMap::new() }
+        <_>::default()
     }
 
     pub fn add_vertex(&mut self, v: u64) {
@@ -58,7 +68,7 @@ impl Graph {
         }
     }
 
-    pub fn neighbors(&self, v: u64) -> Option<&HashMap<u64, f64>> {
+    pub fn neighbors(&self, v: u64) -> Option<&TheMap<u64, f64>> {
         self.adjacency.get(&v)
     }
 
@@ -83,18 +93,24 @@ impl Graph {
             return None;
         }
 
-        let mut dist: HashMap<u64, f64> = HashMap::new();
-        let mut prev: HashMap<u64, u64> = HashMap::new();
-        let mut heap = BinaryHeap::new();
+        // let mut dist = SecMap::<u64, f64>::with_capacity(self.adjacency.len());
+        // let mut prev = SecMap::<u64, u64>::with_capacity(self.adjacency.len());
 
-        dist.insert(start, 0.0);
+        // let mut dist = SecMap::<u64, f64>::with_capacity_and_hasher(self.adjacency.len(), <_>::default());
+        // let mut prev = SecMap::<u64, u64>::with_capacity_and_hasher(self.adjacency.len(), <_>::default());
+
+        // TODO single hashmap
+        let mut dist = vec![(f64::INFINITY, None); self.adjacency.len()];
+        let mut heap = TheHeap::new();
+
+        dist[start as usize] = (0.0, None);
         heap.push(State { cost: 0.0, position: start });
 
         while let Some(State { cost, position }) = heap.pop() {
             if position == end {
                 let mut path = vec![end];
                 let mut current = end;
-                while let Some(&p) = prev.get(&current) {
+                while let Some(&p) = dist[current as usize].1.as_ref() {
                     path.push(p);
                     current = p;
                 }
@@ -102,16 +118,15 @@ impl Graph {
                 return Some((path, cost));
             }
 
-            if cost > dist[&position] {
+            if cost > dist[position as usize].0 {
                 continue;
             }
 
             if let Some(neighbors) = self.adjacency.get(&position) {
                 for (&neighbor, &weight) in neighbors {
                     let next = State { cost: cost + weight, position: neighbor };
-                    if next.cost < *dist.get(&neighbor).unwrap_or(&f64::INFINITY) {
-                        dist.insert(neighbor, next.cost);
-                        prev.insert(neighbor, position);
+                    if next.cost < dist[neighbor as usize].0 {
+                        dist[neighbor as usize] = (next.cost, Some(position));
                         heap.push(next);
                     }
                 }
@@ -172,11 +187,3 @@ impl Graph {
         graph
     }
 }
-
-impl Default for Graph {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-

--- a/src/graph/parallel_search.rs
+++ b/src/graph/parallel_search.rs
@@ -139,7 +139,48 @@ impl<'ctx> Search<'ctx> {
         }
     }
 
-    pub fn run_main_thread(&'ctx self, id: usize, workers: &'ctx [Worker]) {
+    pub fn run(&'ctx self, threads: usize) -> Option<(Vec<u64>, f64)> {
+        let workers = (0..threads).map(|_| Worker::new()).collect::<Vec<_>>();
+        std::thread::scope(|s| {
+            let mut worker_threads = Vec::with_capacity(threads - 1);
+            for id in 1..threads {
+                let workers = &workers[..];
+                let worker = s.spawn(move || {
+                    self.run_worker(id, workers);
+                    // let steals = workers[id].steals.load(Ordering::Relaxed);
+                    // let steal_loops = workers[id].steal_loops.load(Ordering::Relaxed);
+                    // eprintln!(
+                    //     "Worker {} finished with {} steals, {} loops",
+                    //     id, steals, steal_loops
+                    // );
+                });
+                worker_threads.push(worker);
+            }
+            self.run_main_thread(0, &workers[..]);
+
+            // it is a safety measure to detect deadlocks
+            for thread in worker_threads {
+                thread.join().unwrap();
+            }
+        });
+
+        if self.prev[self.end as usize].load(Ordering::Relaxed) == -1 {
+            None
+        } else {
+            let mut path = vec![self.end];
+            let mut prev;
+            while {
+                prev = self.prev[*path.last().unwrap() as usize].load(Ordering::Relaxed);
+                prev >= 0
+            } {
+                path.push(prev as u64);
+            }
+            path.reverse();
+            Some((path, self.costs[self.end as usize].load(Ordering::Relaxed)))
+        }
+    }
+
+    fn run_main_thread(&'ctx self, id: usize, workers: &'ctx [Worker]) {
         workers[0].push(State {
             cost: 0.0,
             position: self.start,
@@ -147,7 +188,7 @@ impl<'ctx> Search<'ctx> {
         self.run_worker(id, workers);
     }
 
-    pub fn run_worker(&'ctx self, id: usize, workers: &'ctx [Worker]) {
+    fn run_worker(&'ctx self, id: usize, workers: &'ctx [Worker]) {
         let mut steals = 0;
         let mut steal_loops = 0;
         let me = &workers[id];

--- a/src/graph/worker.rs
+++ b/src/graph/worker.rs
@@ -1,0 +1,241 @@
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
+
+use crate::atomic::{AtomicF64, AtomicLockGuard, AtomicMutex, AtomicSemaphoreGuard};
+
+// TODO use super::State;
+#[derive(Debug, Clone, PartialEq)]
+struct State {
+    cost: f64,
+    position: u64,
+}
+
+impl State {}
+
+impl Eq for State {}
+
+impl PartialOrd for State {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for State {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other.cost.partial_cmp(&self.cost).unwrap()
+    }
+}
+
+// 4096 should be enough for everone. (c) Bill Gates
+#[derive(Debug)]
+#[repr(align(4096))]
+pub(crate) struct Worker {
+    // Important invariant for the queue: the only the owning worker pushes to it, but anyone can pop (steal) from it.
+    queue: AtomicMutex<super::TheHeap<State>>,
+    size: AtomicUsize,
+    pub(crate) steals: AtomicUsize,
+    pub(crate) steal_loops: AtomicUsize,
+}
+
+impl Worker {
+    pub(crate) fn new() -> Self {
+        Self {
+            queue: AtomicMutex::new(super::TheHeap::new()),
+            size: AtomicUsize::new(0),
+            steals: AtomicUsize::new(0),
+            steal_loops: AtomicUsize::new(0),
+        }
+    }
+
+    fn push(&self, state: State) {
+        self.size.fetch_add(1, Ordering::Relaxed);
+        let mut guard = self.queue.lock();
+        guard.push(state);
+    }
+
+    fn pop(&self) -> Option<State> {
+        self.size.fetch_add(1, Ordering::Relaxed);
+        let mut guard = self.queue.lock();
+        guard.pop()
+    }
+
+    fn try_pop(&self) -> Option<State> {
+        if self.size.load(Ordering::Relaxed) == 0 {
+            return None;
+        }
+        self.queue
+            .try_lock()
+            .and_then(|mut guard| guard.pop())
+            .inspect(|_| {
+                // If we successfully popped, we should decrease the size.
+                self.size.fetch_sub(1, Ordering::Relaxed);
+            })
+    }
+}
+
+struct Node<'search> {
+    // the lock determines "happens after relationship" for the rest of the fields.
+    // the other fields are atomics to be able to read them without a lock and write without UnsafeCell.
+    lock: &'search AtomicBool,
+    cost: &'search AtomicF64,
+    prev: &'search AtomicI64,
+}
+
+impl<'search> Node<'search> {
+    pub fn new(search: &'search Search, position: u64) -> Self {
+        let position = position as usize;
+        Self {
+            lock: &search.locks[position],
+            cost: &search.costs[position],
+            prev: &search.prev[position],
+        }
+    }
+
+    pub(crate) fn try_to_supercede(&self, cost: f64, prev: u64) -> bool {
+        if cost < self.cost.load(Ordering::Relaxed) {
+            let _cell_guard = AtomicLockGuard::lock(self.lock);
+            if cost < self.cost.load(Ordering::Relaxed) {
+                // we are still better!
+                self.cost.store(cost, Ordering::Relaxed);
+                self.prev.store(prev as i64, Ordering::Relaxed);
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Search<'graph> {
+    graph: &'graph super::Graph,
+    waiters: AtomicU64,
+
+    // See the `Node` struct comments for some explanations.
+    locks: Box<[AtomicBool]>,
+    pub(crate) costs: Box<[AtomicF64]>,
+    pub(crate) prev: Box<[AtomicI64]>,
+}
+
+impl<'ctx> Search<'ctx> {
+    pub fn new(graph: &'ctx super::Graph, start: u64) -> Self {
+        let size = graph.adjacency.len() + 1;
+        let mut locks = Vec::with_capacity(size);
+        let mut costs = Vec::with_capacity(size);
+        let mut prev = Vec::with_capacity(size);
+        for _ in 0..size {
+            locks.push(AtomicBool::new(false));
+            costs.push(AtomicF64::new(f64::INFINITY));
+            prev.push(AtomicI64::new(-1));
+        }
+        costs[start as usize].store(0.0, Ordering::Relaxed);
+
+        Self {
+            graph,
+            waiters: AtomicU64::new(0),
+            locks: locks.into_boxed_slice(),
+            costs: costs.into_boxed_slice(),
+            prev: prev.into_boxed_slice(),
+        }
+    }
+
+    pub fn start_work(&'ctx self, id: usize, workers: &'ctx [Worker], start: u64) {
+        workers[0].push(State {
+            cost: 0.0,
+            position: start,
+        });
+        self.run_worker(id, workers);
+    }
+
+    pub fn run_worker(&'ctx self, id: usize, workers: &'ctx [Worker]) {
+        let mut steals = 0;
+        let mut steal_loops = 0;
+        let me = &workers[id];
+        let mut stolen_state = None;
+
+        'main: loop {
+            // Try to do all the work we have
+            'work: loop {
+                let state = match stolen_state.take() {
+                    Some(state) => state,
+                    None => {
+                        // If we have no local state, try to pop from our queue.
+                        if let Some(state) = me.pop() {
+                            state
+                        } else {
+                            // If we have no local work, we may try to steal it.
+                            break 'work;
+                        }
+                    }
+                };
+
+                let node = Node::new(self, state.position);
+                // if we are still relevant, i.e. our cost is still the best known.
+                if state.cost <= node.cost.load(Ordering::Relaxed) {
+                    for (&neighbor, &weight) in self
+                        .graph
+                        .adjacency
+                        .get(&state.position)
+                        .into_iter()
+                        .flatten()
+                    {
+                        let next_cost = state.cost + weight;
+                        let nei_node = Node::new(self, neighbor);
+
+                        if nei_node.try_to_supercede(next_cost, state.position) {
+                            let next = State {
+                                cost: next_cost,
+                                position: neighbor,
+                            };
+                            me.push(next);
+                        }
+                    }
+                }
+            }
+
+            // Try to steal some work.
+            let waiting_guard = AtomicSemaphoreGuard::increment(
+                &self.waiters,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+            if let Some(state) = self.steal_some_work(id, workers, &mut steals, &mut steal_loops) {
+                // else handle the new work
+                std::mem::drop(waiting_guard);
+                // we do not put it into our worker queue to avoid repeated stealing.
+                stolen_state = Some(state);
+                continue 'main;
+            } else {
+                // If we are here, all the threads are waiting for work, i.e. there is no more work, and we are
+                // terminating. Keep the counter incremented to avoid a race conditions.
+                std::mem::forget(waiting_guard);
+                workers[id].steals.fetch_add(steals, Ordering::Relaxed);
+                workers[id]
+                    .steal_loops
+                    .fetch_add(steal_loops, Ordering::Relaxed);
+                return;
+            }
+        }
+    }
+
+    fn steal_some_work(
+        &'ctx self,
+        id: usize,
+        workers: &'ctx [Worker],
+        steals: &mut usize,
+        steal_loops: &mut usize,
+    ) -> Option<State> {
+        *steal_loops += 1;
+        let workers_len = workers.len();
+        while self.waiters.load(Ordering::Relaxed) != workers_len as u64 {
+            for n_offset in 1..workers_len {
+                *steals += 1;
+                let neighbor_id = (id + n_offset) % workers_len;
+                if let Some(state) = workers[neighbor_id].try_pop() {
+                    return Some(state);
+                }
+                std::thread::yield_now();
+            }
+        }
+        None
+    }
+}

--- a/src/graph/worker.rs
+++ b/src/graph/worker.rs
@@ -1,15 +1,16 @@
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
 
-use crate::atomic::{AtomicF64, AtomicLockGuard, AtomicMutex, AtomicSemaphoreGuard};
 use super::State;
+use crate::atomic::{AtomicF64, AtomicLockGuard, AtomicMutex, AtomicSemaphoreGuard};
 
 // 4096 bytes should be enough for everone.
-#[derive(Debug)]
+// Unlike `Search`'s data (costs, locks, etc), `Worker`'s data is highly contended, so we want to avoid false sharing.
+// It gives 8% performance improvement on my machine.
 #[repr(align(4096))]
 pub(crate) struct Worker {
     // Important invariant for the queue: the only the owning worker pushes to it, but anyone can pop (steal) from it.
     queue: AtomicMutex<super::TheHeap<State>>,
-    size: AtomicUsize,
+    // These metrics are updated at thread termination, and can be removed completely.
     pub(crate) steal_attempts: AtomicUsize,
     pub(crate) steal_loops: AtomicUsize,
 }
@@ -18,20 +19,17 @@ impl Worker {
     pub(crate) fn new() -> Self {
         Self {
             queue: AtomicMutex::new(super::TheHeap::new()),
-            size: AtomicUsize::new(0),
             steal_attempts: AtomicUsize::new(0),
             steal_loops: AtomicUsize::new(0),
         }
     }
 
     fn push(&self, state: State) {
-        self.size.fetch_add(1, Ordering::Relaxed);
         let mut guard = self.queue.lock();
         guard.push(state);
     }
 
     fn pop(&self) -> Option<State> {
-        self.size.fetch_add(1, Ordering::Relaxed);
         let mut guard = self.queue.lock();
         guard.pop()
     }
@@ -39,20 +37,10 @@ impl Worker {
     fn clear(&self) {
         let mut guard = self.queue.lock();
         guard.clear();
-        self.size.store(0, Ordering::Relaxed);
     }
 
     fn try_pop(&self) -> Option<State> {
-        if self.size.load(Ordering::Relaxed) == 0 {
-            return None;
-        }
-        self.queue
-            .try_lock()
-            .and_then(|mut guard| guard.pop())
-            .inspect(|_| {
-                // If we successfully popped, we should decrease the size.
-                self.size.fetch_sub(1, Ordering::Relaxed);
-            })
+        self.queue.try_lock().and_then(|mut guard| guard.pop())
     }
 }
 
@@ -78,7 +66,7 @@ impl<'search> Node<'search> {
         if cost < self.cost.load(Ordering::Relaxed) {
             let _cell_guard = AtomicLockGuard::lock(self.lock);
             if cost < self.cost.load(Ordering::Relaxed) {
-                // we are still better!
+                // our cost is still better!
                 self.cost.store(cost, Ordering::Relaxed);
                 self.prev.store(prev as i64, Ordering::Relaxed);
                 return true;
@@ -92,7 +80,7 @@ impl<'search> Node<'search> {
 #[derive(Debug)]
 pub(crate) struct Search<'graph> {
     graph: &'graph super::Graph,
-    waiters: AtomicU64,
+    waitings: AtomicU64,
     start: u64,
     end: u64,
 
@@ -117,7 +105,7 @@ impl<'ctx> Search<'ctx> {
 
         Self {
             graph,
-            waiters: AtomicU64::new(0),
+            waitings: AtomicU64::new(0),
             start,
             end,
             locks: locks.into_boxed_slice(),
@@ -126,7 +114,7 @@ impl<'ctx> Search<'ctx> {
         }
     }
 
-    pub fn start_work(&'ctx self, id: usize, workers: &'ctx [Worker]) {
+    pub fn run_main_thread(&'ctx self, id: usize, workers: &'ctx [Worker]) {
         workers[0].push(State {
             cost: 0.0,
             position: self.start,
@@ -188,9 +176,9 @@ impl<'ctx> Search<'ctx> {
 
             // Try to steal some work.
             let waiting_guard = AtomicSemaphoreGuard::increment(
-                &self.waiters,
+                &self.waitings,
                 Ordering::Relaxed,
-                Ordering::Relaxed,
+                Ordering::Release,
             );
             if let Some(state) = self.steal_some_work(id, workers, &mut steals, &mut steal_loops) {
                 // else handle the new work
@@ -199,10 +187,12 @@ impl<'ctx> Search<'ctx> {
                 stolen_state = Some(state);
                 continue 'main;
             } else {
-                // If we are here, all the threads are waiting for work, i.e. there is no more work, and we are
-                // terminating. Keep the counter incremented to avoid a race conditions.
+                // If we are here, all the threads are waiting for a work, i.e. there is no more work, and we are
+                // terminating. Keep the counter incremented to avoid a race condition.
                 std::mem::forget(waiting_guard);
-                workers[id].steal_attempts.fetch_add(steals, Ordering::Relaxed);
+                workers[id]
+                    .steal_attempts
+                    .fetch_add(steals, Ordering::Relaxed);
                 workers[id]
                     .steal_loops
                     .fetch_add(steal_loops, Ordering::Relaxed);
@@ -213,17 +203,17 @@ impl<'ctx> Search<'ctx> {
 
     fn steal_some_work(
         &'ctx self,
-        id: usize,
+        my_id: usize,
         workers: &'ctx [Worker],
         steals: &mut usize,
         steal_loops: &mut usize,
     ) -> Option<State> {
         *steal_loops += 1;
         let workers_len = workers.len();
-        while self.waiters.load(Ordering::Relaxed) != workers_len as u64 {
+        while self.waitings.load(Ordering::Acquire) != workers_len as u64 {
             for n_offset in 1..workers_len {
                 *steals += 1;
-                let neighbor_id = (id + n_offset) % workers_len;
+                let neighbor_id = (my_id + n_offset) % workers_len;
                 if let Some(state) = workers[neighbor_id].try_pop() {
                     return Some(state);
                 }

--- a/src/graph/worker.rs
+++ b/src/graph/worker.rs
@@ -3,6 +3,10 @@ use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering}
 use super::State;
 use crate::atomic::{AtomicF64, AtomicLockGuard, AtomicMutex, AtomicSemaphoreGuard};
 
+// Do not steal if the queue is smaller (0 or 1).
+// It prevents a race condition at the end of the work.
+const MIN_QUEUE_STEAL_SIZE: usize = 2;
+
 // 4096 bytes should be enough for everone.
 // Unlike `Search`'s data (costs, locks, etc), `Worker`'s data is highly contended, so we want to avoid false sharing.
 // It gives 8% performance improvement on my machine.
@@ -10,6 +14,7 @@ use crate::atomic::{AtomicF64, AtomicLockGuard, AtomicMutex, AtomicSemaphoreGuar
 pub(crate) struct Worker {
     // Important invariant for the queue: the only the owning worker pushes to it, but anyone can pop (steal) from it.
     queue: AtomicMutex<super::TheHeap<State>>,
+    queue_size: AtomicUsize,
     // These metrics are updated at thread termination, and can be removed completely.
     pub(crate) steal_attempts: AtomicUsize,
     pub(crate) steal_loops: AtomicUsize,
@@ -19,6 +24,7 @@ impl Worker {
     pub(crate) fn new() -> Self {
         Self {
             queue: AtomicMutex::new(super::TheHeap::new()),
+            queue_size: AtomicUsize::new(0),
             steal_attempts: AtomicUsize::new(0),
             steal_loops: AtomicUsize::new(0),
         }
@@ -27,20 +33,39 @@ impl Worker {
     fn push(&self, state: State) {
         let mut guard = self.queue.lock();
         guard.push(state);
+        self.queue_size.fetch_add(1, Ordering::Relaxed);
     }
 
     fn pop(&self) -> Option<State> {
         let mut guard = self.queue.lock();
-        guard.pop()
+        guard.pop().inspect(|_| {
+            self.queue_size.fetch_sub(1, Ordering::Relaxed);
+        })
     }
 
     fn clear(&self) {
         let mut guard = self.queue.lock();
         guard.clear();
+        self.queue_size.store(0, Ordering::Relaxed);
     }
 
-    fn try_pop(&self) -> Option<State> {
-        self.queue.try_lock().and_then(|mut guard| guard.pop())
+    fn try_steal(&self, min_size: usize) -> Option<State> {
+        if self.queue_size.load(Ordering::Relaxed) >= min_size {
+            self.queue
+                .try_lock()
+                .and_then(|mut guard| {
+                    if guard.len() >= min_size {
+                        guard.pop()
+                    } else {
+                        None
+                    }
+                })
+                .inspect(|_| {
+                    self.queue_size.fetch_sub(1, Ordering::Relaxed);
+                })
+        } else {
+            None
+        }
     }
 }
 
@@ -66,7 +91,7 @@ impl<'search> Node<'search> {
         if cost < self.cost.load(Ordering::Relaxed) {
             let _cell_guard = AtomicLockGuard::lock(self.lock);
             if cost < self.cost.load(Ordering::Relaxed) {
-                // our cost is still better!
+                // our cost is still better!  updating.
                 self.cost.store(cost, Ordering::Relaxed);
                 self.prev.store(prev as i64, Ordering::Relaxed);
                 return true;
@@ -183,7 +208,7 @@ impl<'ctx> Search<'ctx> {
             if let Some(state) = self.steal_some_work(id, workers, &mut steals, &mut steal_loops) {
                 // else handle the new work
                 std::mem::drop(waiting_guard);
-                // we do not put it into our worker queue to avoid repeated stealing.
+                // do not put it into our worker queue just to fetch immediately.
                 stolen_state = Some(state);
                 continue 'main;
             } else {
@@ -214,7 +239,7 @@ impl<'ctx> Search<'ctx> {
             for n_offset in 1..workers_len {
                 *steals += 1;
                 let neighbor_id = (my_id + n_offset) % workers_len;
-                if let Some(state) = workers[neighbor_id].try_pop() {
+                if let Some(state) = workers[neighbor_id].try_steal(MIN_QUEUE_STEAL_SIZE) {
                     return Some(state);
                 }
                 std::thread::yield_now();

--- a/src/graph/worker.rs
+++ b/src/graph/worker.rs
@@ -1,38 +1,16 @@
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicUsize, Ordering};
 
 use crate::atomic::{AtomicF64, AtomicLockGuard, AtomicMutex, AtomicSemaphoreGuard};
+use super::State;
 
-// TODO use super::State;
-#[derive(Debug, Clone, PartialEq)]
-struct State {
-    cost: f64,
-    position: u64,
-}
-
-impl State {}
-
-impl Eq for State {}
-
-impl PartialOrd for State {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for State {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        other.cost.partial_cmp(&self.cost).unwrap()
-    }
-}
-
-// 4096 should be enough for everone. (c) Bill Gates
+// 4096 bytes should be enough for everone.
 #[derive(Debug)]
 #[repr(align(4096))]
 pub(crate) struct Worker {
     // Important invariant for the queue: the only the owning worker pushes to it, but anyone can pop (steal) from it.
     queue: AtomicMutex<super::TheHeap<State>>,
     size: AtomicUsize,
-    pub(crate) steals: AtomicUsize,
+    pub(crate) steal_attempts: AtomicUsize,
     pub(crate) steal_loops: AtomicUsize,
 }
 
@@ -41,7 +19,7 @@ impl Worker {
         Self {
             queue: AtomicMutex::new(super::TheHeap::new()),
             size: AtomicUsize::new(0),
-            steals: AtomicUsize::new(0),
+            steal_attempts: AtomicUsize::new(0),
             steal_loops: AtomicUsize::new(0),
         }
     }
@@ -56,6 +34,12 @@ impl Worker {
         self.size.fetch_add(1, Ordering::Relaxed);
         let mut guard = self.queue.lock();
         guard.pop()
+    }
+
+    fn clear(&self) {
+        let mut guard = self.queue.lock();
+        guard.clear();
+        self.size.store(0, Ordering::Relaxed);
     }
 
     fn try_pop(&self) -> Option<State> {
@@ -109,6 +93,8 @@ impl<'search> Node<'search> {
 pub(crate) struct Search<'graph> {
     graph: &'graph super::Graph,
     waiters: AtomicU64,
+    start: u64,
+    end: u64,
 
     // See the `Node` struct comments for some explanations.
     locks: Box<[AtomicBool]>,
@@ -117,7 +103,7 @@ pub(crate) struct Search<'graph> {
 }
 
 impl<'ctx> Search<'ctx> {
-    pub fn new(graph: &'ctx super::Graph, start: u64) -> Self {
+    pub fn new(graph: &'ctx super::Graph, start: u64, end: u64) -> Self {
         let size = graph.adjacency.len() + 1;
         let mut locks = Vec::with_capacity(size);
         let mut costs = Vec::with_capacity(size);
@@ -132,16 +118,18 @@ impl<'ctx> Search<'ctx> {
         Self {
             graph,
             waiters: AtomicU64::new(0),
+            start,
+            end,
             locks: locks.into_boxed_slice(),
             costs: costs.into_boxed_slice(),
             prev: prev.into_boxed_slice(),
         }
     }
 
-    pub fn start_work(&'ctx self, id: usize, workers: &'ctx [Worker], start: u64) {
+    pub fn start_work(&'ctx self, id: usize, workers: &'ctx [Worker]) {
         workers[0].push(State {
             cost: 0.0,
-            position: start,
+            position: self.start,
         });
         self.run_worker(id, workers);
     }
@@ -167,6 +155,12 @@ impl<'ctx> Search<'ctx> {
                         }
                     }
                 };
+
+                let end_cost = self.costs[self.end as usize].load(Ordering::Relaxed);
+                if state.cost >= end_cost {
+                    me.clear();
+                    break 'work;
+                }
 
                 let node = Node::new(self, state.position);
                 // if we are still relevant, i.e. our cost is still the best known.
@@ -208,7 +202,7 @@ impl<'ctx> Search<'ctx> {
                 // If we are here, all the threads are waiting for work, i.e. there is no more work, and we are
                 // terminating. Keep the counter incremented to avoid a race conditions.
                 std::mem::forget(waiting_guard);
-                workers[id].steals.fetch_add(steals, Ordering::Relaxed);
+                workers[id].steal_attempts.fetch_add(steals, Ordering::Relaxed);
                 workers[id]
                     .steal_loops
                     .fetch_add(steal_loops, Ordering::Relaxed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,2 @@
-pub mod graph;
 pub mod atomic;
+pub mod graph;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
-pub mod graph; 
+pub mod graph;
+pub mod atomic;

--- a/tests/graph_tests.rs
+++ b/tests/graph_tests.rs
@@ -54,6 +54,19 @@ fn test_shortest_path() {
 }
 
 #[test]
+fn test_shortest_path_parallel() {
+    let mut g = Graph::new();
+    g.add_edge(1, 2, 1.0);
+    g.add_edge(2, 3, 2.0);
+    g.add_edge(1, 4, 4.0);
+    g.add_edge(4, 3, 1.0);
+    let (path, cost) = g.parallel_shortest_path(1, 3, 4).unwrap();
+    assert_eq!(path, vec![1, 2, 3]);
+    assert_eq!(cost, 3.0);
+    assert!(g.shortest_path(3, 1).is_none());
+}
+
+#[test]
 fn test_weighted_shortest_path() {
     let mut g = Graph::new();
     g.add_edge(1, 2, 5.0);
@@ -83,7 +96,7 @@ fn test_complex_shortest_path() {
     // Test shortest path from 1 to 5
     // Path options:
     // 1 -> 6 -> 7 -> 5 = 2 + 5 + 3 = 10
-    // 1 -> 2 -> 7 -> 5 = 4 + 3 + 3 = 10  
+    // 1 -> 2 -> 7 -> 5 = 4 + 3 + 3 = 10
     // 1 -> 8 -> 5 = 6 + 4 = 10
     // 1 -> 2 -> 3 -> 4 -> 5 = 4 + 2 + 3 + 1 = 10
     let (path1, cost1) = g.shortest_path(1, 5).unwrap();
@@ -105,7 +118,46 @@ fn test_complex_shortest_path() {
     assert!(g.shortest_path(5, 1).is_none());
 }
 
+#[test]
+fn test_complex_parallel_shortest_path() {
+    let mut g = Graph::new();
+    // Create a more complex graph with multiple possible paths
+    g.add_edge(1, 2, 4.0);
+    g.add_edge(2, 3, 2.0);
+    g.add_edge(3, 4, 3.0);
+    g.add_edge(4, 5, 1.0);
+    g.add_edge(1, 6, 2.0);
+    g.add_edge(6, 7, 5.0);
+    g.add_edge(7, 5, 3.0);
+    g.add_edge(1, 8, 6.0);
+    g.add_edge(8, 5, 4.0);
+    g.add_edge(2, 7, 3.0);
+    g.add_edge(3, 8, 5.0);
 
+    // Test shortest path from 1 to 5
+    // Path options:
+    // 1 -> 6 -> 7 -> 5 = 2 + 5 + 3 = 10
+    // 1 -> 2 -> 7 -> 5 = 4 + 3 + 3 = 10
+    // 1 -> 8 -> 5 = 6 + 4 = 10
+    // 1 -> 2 -> 3 -> 4 -> 5 = 4 + 2 + 3 + 1 = 10
+    let (path1, cost1) = g.parallel_shortest_path(1, 5, 4).unwrap();
+    // The algorithm found [1, 8, 5] which is correct (cost = 10)
+    assert_eq!(cost1, 10.0);
+    assert!(path1.len() >= 2);
+
+    // Test shortest path from 1 to 8
+    let (path2, cost2) = g.parallel_shortest_path(1, 8, 4).unwrap();
+    assert_eq!(path2, vec![1, 8]);
+    assert_eq!(cost2, 6.0);
+
+    // Test shortest path from 2 to 5
+    let (path3, cost3) = g.parallel_shortest_path(2, 5, 4).unwrap();
+    assert_eq!(path3, vec![2, 7, 5]);
+    assert_eq!(cost3, 6.0);
+
+    // Test non-existent path
+    assert!(g.parallel_shortest_path(5, 1, 4).is_none());
+}
 
 #[test]
 fn test_unweighted_edge() {
@@ -114,20 +166,35 @@ fn test_unweighted_edge() {
     assert_eq!(g.get_edge_weight(1, 2), Some(1.0));
 }
 
-
 #[test]
 fn test_random_connected_graph() {
     let graph = Graph::random_connected_graph(10, 5, 1.0, 10.0);
-    
+
     // Check that we have the right number of vertices
     assert_eq!(graph.adjacency.len(), 10);
-    
+
     // Count edges (should be at least 9 for connectivity + 5 additional)
-    let edge_count: usize = graph.adjacency.values().map(|neighbors| neighbors.len()).sum();
+    let edge_count: usize = graph
+        .adjacency
+        .values()
+        .map(|neighbors| neighbors.len())
+        .sum();
     assert!(edge_count >= 14); // 9 for spanning tree + 5 additional
-    
+
     // Check connectivity by ensuring there's a path from 0 to 9
     let (path, _cost) = graph.shortest_path(0, 9).unwrap();
     assert!(!path.is_empty());
-    
+}
+
+#[test]
+fn parallel_vs_single_thread() {
+    const BENCH_SIZE: u64 = 900000;
+    const THREADS: usize = 4;
+
+    let g = Graph::random_connected_graph(BENCH_SIZE, BENCH_SIZE as usize / 100, 1.0, 10.0);
+
+    let single = g.shortest_path(0, BENCH_SIZE - 1);
+    let parallel = g.parallel_shortest_path(0, BENCH_SIZE - 1, THREADS);
+
+    assert_eq!(single, parallel);
 }

--- a/tests/qc.rs
+++ b/tests/qc.rs
@@ -1,0 +1,18 @@
+
+#[quickcheck_macros::quickcheck]
+fn qc_parallel_vs_single_thread(seed: u64) {
+    use graph_challenge::graph::Graph;
+    use rand::{SeedableRng as _, Rng as _};
+
+    const GRAPH_SIZE: u64 = 90000;
+    const THREADS: usize = 4;
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let g = Graph::random_connected_graph_with_rng(GRAPH_SIZE, GRAPH_SIZE as usize / 100, 1.0, 10.0, &mut rng);
+    let end = rng.gen_range((GRAPH_SIZE - GRAPH_SIZE/9)..GRAPH_SIZE);
+
+    let single = dbg!(g.shortest_path(0, end));
+    let parallel = dbg!(g.parallel_shortest_path(0, end, THREADS));
+
+    assert_eq!(single, parallel);
+}

--- a/tests/qc.rs
+++ b/tests/qc.rs
@@ -1,15 +1,20 @@
-
 #[quickcheck_macros::quickcheck]
 fn qc_parallel_vs_single_thread(seed: u64) {
     use graph_challenge::graph::Graph;
-    use rand::{SeedableRng as _, Rng as _};
+    use rand::{Rng as _, SeedableRng as _};
 
     const GRAPH_SIZE: u64 = 90000;
     const THREADS: usize = 4;
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-    let g = Graph::random_connected_graph_with_rng(GRAPH_SIZE, GRAPH_SIZE as usize / 100, 1.0, 10.0, &mut rng);
-    let end = rng.gen_range((GRAPH_SIZE - GRAPH_SIZE/9)..GRAPH_SIZE);
+    let g = Graph::random_connected_graph_with_rng(
+        GRAPH_SIZE,
+        GRAPH_SIZE as usize / 100,
+        1.0,
+        10.0,
+        &mut rng,
+    );
+    let end = rng.gen_range((GRAPH_SIZE - GRAPH_SIZE / 9)..GRAPH_SIZE);
 
     let single = dbg!(g.shortest_path(0, end));
     let parallel = dbg!(g.parallel_shortest_path(0, end, THREADS));


### PR DESCRIPTION
# Report

## Base version improvements

Single-thread version was improved in the following ways:

1. Instead of std's binary heap, `dary_heap::QuaternaryHeap` was used.  It
   utilises cache better, and gives significant performance for
   `Graph::shortest_path`.
2. `Graph::adjacency` uses a hashmap with much simpler hasher from crate
   `nohash_hasher`.  `rustc-hash` can also be used, but its speedup is not as
   large.  It improves both `Graph::random_connected_graph` and
   `Graph::shortest_path`.
3. Presuming that vertex IDs are in range 0..n, vectors are used to store
   weights and previous vertex index.

   We may reorganize the API, keep an `bimap` table to keep a correspondence
   between arbitrary vertex IDs and positions, or just require that the IDs
   cannot be sparse.

|                                             | old       | new       |         |
|---------------------------------------------|-----------|-----------|---------|
|shortest path on random connected graph, ARM | 3.4230 µs | 1.1198 µs | -67.452%|
| -// -, x64                                  | 6.3577 µs | 1.9425 µs | -69.664%|
|generate random connected graph, ARM         | 18.312 µs | 10.796 µs | -41.080%|
| -//-, x64                                   | 24.573 µs | 14.935 µs | -39.254%|

(ARM: MacOS M1, x64: Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70GHz at DigitalOcean).

## Parallel version

The parallel version consists of `threads` workers each having own priority
queue (the very same `dary_heap::QuaternaryHeap`).  They share the same
read-only `Graph` instance, and also `costs` (i.e. `dist`), a slice of custom
`&[AtomicF64]` type, `prev` of `&[AtomicIsize]`, and `locks` of `&[AtomicBool]`
for coordinated update of the two formers.

The idea of working with these values is:

1. Reading atomically an element of `costs` with relaxed ordering is safe
   because the cost is never increasing.  If we get a stale value, worst thing
   that would happen is trying to lock one of the `locks` only to found that
   actual value is smaller.  But it is a rare event.
2. Reading of `prev` only happens after all the threads are finished their work.
   Updating `prev` is done together with `costs` under lock `locks[i]` that
   induce "happens before" for both fields.

The workers's queues are also guarded by an `AtomicBool`, but most of the time
they do work with own data uncontended.  However, when a worker has no work, it
tries to steal some work from other worker, locking on his queue, in round-robin
fashion (it also happens at start: only the main thread gets a seed value).

When a worker runs out of work, it increases an atomic `waitings` counter. When
the counter is equal to number of threads, all the threads except the main one,
terminate.

### Benchmarking parallel version

Parallel version makes sense only on larger graph; unfortunately, large graph's
search time varies greatly depending on graph's structure. To mitigate this
problem, 5 random graphs are generated, and each implementation is run on all of
them.

|                | ARM        | x64       |
|----------------|------------|-----------|
| seq-5x         | 199.76 ms  | 455.39 ms |
| par-5x         | 113.67 ms  | 308.58 ms |
| speedup        | 1.7        | 1.47      |
| efficiency     | 0.43       | 0.38      |

(ARM: MacOS M1, x64: Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70GHz at DigitalOcean).

The efficiency is way below 1 is not only because of synchronization costs, but
because threads, having the priority queue split, do calculations for suboptimal paths
too. But it is still faster overall.
